### PR TITLE
Mapped attribute names have priority

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@ New features and enhancements
 * New function ``xscen.ensemble.ensemble_stats`` added. (:issue:`3`, :pull:`28`).
 * Add argument ``intermediate_reg_grids`` to ``xscen.regridding.regrid``. (:issue:`34`, :pull:`39`).
 * Add argument ``moving_yearly_window`` to ``xscen.biasadjust.adjust``. (:pull:`39`).
-* Many adjustments to ``parse_directory``: better wildcards (:issue:`24`), allow custom columns, fastpaths for ``parse_from_ds``, and more (:pull:`30`).
+* Many adjustments to ``parse_directory``: better wildcards (:issue:`24`), allow custom columns, fastpaths for ``parse_from_ds``, and more (:pull:`30`, :pull:`47`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -994,10 +994,10 @@ def parse_from_ds(
             attrs["date_start"] = time[0]
         elif name == "date_end" and time is not None:
             attrs["date_end"] = time[-1]
-        elif name in ds_attrs:
-            attrs[name] = ds_attrs[name].strip()
         elif name in rev_attrs_map and rev_attrs_map[name] in ds_attrs:
             attrs[name] = ds_attrs[rev_attrs_map[name]].strip()
+        elif name in ds_attrs:
+            attrs[name] = ds_attrs[name].strip()
 
     logger.debug(f"Got fields {attrs.keys()} from file.")
     return attrs


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* When parsing the attributes of a dataset within `parse_directory`, attributes for which we gave a mapping through the "CVs" should have priority over an attribute that has the same name.

EX: If a dataset has the attributes:
```
driving_experiment_name = 'historical'
experiment = 'conditions initiales perturbées'
```
and I give `CVs={'attributes': {'driving_experiment_name': 'experiment'}}`. In this case I want `'historical'` as the final value for field `'experiment'`. 

In the previous version, as changed in #30, the order of checks was wrong and the "wrong" attribute got parsed.

### Does this PR introduce a breaking change?
No

### Other information:
