### PR TITLE
Fix 57

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliet
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* N/A
+* Add argument `resample_method` to `xs.extract.resample`. (:issue:`57`, :pull:`57`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -17,6 +17,7 @@ Breaking changes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Small bugfixes in aggregate.py (:pull:`55`, :pull:`56`).
+* Default method of `xs.extract.resample` now depends on frequency. (:issue:`57`, :pull:`57`).
 
 v0.3.0 (2022-08-23)
 -------------------

--- a/xscen/CVs/resampling_methods.json
+++ b/xscen/CVs/resampling_methods.json
@@ -1,8 +1,14 @@
 {
+    "any":
+  {
 	"sfcWindfromdir": "wind_direction",
 	"sfcWind": "wind_direction",
 	"uas": "wind_direction",
-	"vas": "wind_direction",
+	"vas": "wind_direction"
+  },
+    "D":
+  {
 	"tasmin": "min",
 	"tasmax": "max"
+  }
 }

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -131,7 +131,7 @@ def extract_dataset(
     xr_open_kwargs: dict = None,
     xr_combine_kwargs: dict = None,
     preprocess: Callable = None,
-    resampling_method: Optional[str] = None,
+    resample_method: Optional[str] = None,
 ) -> Union[dict, xr.Dataset]:
     """
     Takes one element of the output of `search_data_catalogs` and returns a dataset,
@@ -163,7 +163,7 @@ def extract_dataset(
       will be passed to `xr.combine_by_coords`.
     preprocess : callable, optional
       If provided, call this function on each dataset prior to aggregation.
-    resampling_method : {'mean', 'min', 'max', 'sum', 'wind_direction'}, optional
+    resample_method : {'mean', 'min', 'max', 'sum', 'wind_direction'}, optional
       The resampling method. If None (default), it is guessed from the variable name and frequency,
       using the mapping in CVs/resampling_methods.json. If the variable is not found there,
       "mean" is used by default.
@@ -291,7 +291,7 @@ def extract_dataset(
                                     da,
                                     variables_and_freqs[var_name],
                                     ds=ds_ts,
-                                    method=resampling_method,
+                                    method=resample_method,
                                 )
                             }
                         )


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #57 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* default `method` for `resample` now looks at the frequency
* `resample_method` added to `extract_dataset` if we want to override the default for some reason

### Does this PR introduce a breaking change?

yes, previously resampling tasmax/tasmin would always use method max/min. Now, this is only the case for resampling to 'D'.
### Other information:
