### PR TITLE
Fix unstack

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * New functions ``diagnostics.properties_and_measures``, ``diagnostics.measures_heatmap`` and ``diagnostics.measures_improvement``. (:issue:`5`, :pull:`53`)
 * Add argument `resample_methods` to `xs.extract.resample`. (:issue:`57`, :pull:`57`)
+* ``xs.utils.stack_drop_nans``/ ``xs.utils.unstack_fill_nan`` will now format the `to_file`/`coords` string to add the domain and the shape. (:issue:`59`, :pull:`67`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -241,6 +241,7 @@ def compute_deltas(
     return deltas
 
 
+@parse_config
 def spatial_mean(
     ds: xr.Dataset,
     method: str,

--- a/xscen/diagnostics.py
+++ b/xscen/diagnostics.py
@@ -16,6 +16,7 @@ from xclim.core.units import convert_units_to
 from xclim.sdba import measures
 
 from .catalog import DataCatalog
+from .config import parse_config
 from .indicators import load_xclim_module
 from .io import save_to_zarr
 from .utils import change_units, maybe_unstack, unstack_fill_nan
@@ -113,6 +114,7 @@ def _invert_unphysical_temperatures(
 # TODO: just measures?
 
 
+@parse_config
 def properties_and_measures(
     ds: xr.Dataset,
     properties: Union[

--- a/xscen/diagnostics.py
+++ b/xscen/diagnostics.py
@@ -220,8 +220,8 @@ def properties_and_measures(
                 sim=prop[vname], ref=dref_for_measure[vname]
             )
             # create a merged long_name
-            prop_ln = prop[vname].attrs.pop("long_name", "").replace(".", "")
-            meas_ln = meas[vname].attrs.pop("long_name", "").lower()
+            prop_ln = prop[vname].attrs.get("long_name", "").replace(".", "")
+            meas_ln = meas[vname].attrs.get("long_name", "").lower()
             meas[vname].attrs["long_name"] = f"{prop_ln} {meas_ln}"
 
     for ds1 in [prop, meas]:

--- a/xscen/ensembles.py
+++ b/xscen/ensembles.py
@@ -6,13 +6,15 @@ import pandas as pd
 import xarray as xr
 from xclim import ensembles
 
-from .catalog import generate_id  # ProjectCatalog
+from .catalog import generate_id
+from .config import parse_config
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["ensemble_stats"]
 
 
+@parse_config
 def ensemble_stats(
     datasets: Any,
     create_kwargs: dict = None,

--- a/xscen/io.py
+++ b/xscen/io.py
@@ -273,6 +273,7 @@ def clean_incomplete(path: Union[str, os.PathLike], complete: Sequence[str]) -> 
             sh.rmtree(fold)
 
 
+@parse_config
 def save_to_netcdf(
     ds: xr.Dataset,
     filename: str,
@@ -342,6 +343,7 @@ def save_to_netcdf(
     ds.to_netcdf(filename, **netcdf_kwargs)
 
 
+@parse_config
 def save_to_zarr(
     ds: xr.Dataset,
     filename: str,

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -213,8 +213,9 @@ def unstack_fill_nan(
 
     if not isinstance(coords, (list, tuple)) and coords is not None:
         if isinstance(coords, (str, os.PathLike)):
-            original_shape = ds.lat.attrs["original_shape"]
-            coords = coords.format(domain=ds.attrs["cat:domain"], shape=original_shape)
+            original_shape = ds.lat.attrs.get("original_shape", "unknown_shape")
+            domain = ds.attrs.get("cat:domain", "unknown_domain")
+            coords = coords.format(domain=domain, shape=original_shape)
             logger.info(f"Dataset unstacked using {coords}.")
             coords = xr.open_dataset(coords)
         out = out.reindex(**coords.coords)

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -247,6 +247,7 @@ def get_cat_attrs(ds: Union[xr.Dataset, dict]):
     return {k[4:]: v for k, v in attrs.items() if k.startswith("cat:")}
 
 
+@parse_config
 def maybe_unstack(
     ds: xr.Dataset,
     coords: str = None,
@@ -375,6 +376,7 @@ def change_units(ds: xr.Dataset, variables_and_units: dict) -> xr.Dataset:
     return ds
 
 
+@parse_config
 def clean_up(
     ds: xr.Dataset,
     variables_and_units: Optional[dict] = None,

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -98,7 +98,6 @@ def stack_drop_nans(
       the original shape of the dataset and the global attributes 'cat:domain'.
       If None (default), nothing is written to disk.
       It is recommended to fill this argument in the config. Ex:
-      .. code-block:: yaml
 
           utils:
             stack_drop_nans:
@@ -173,7 +172,6 @@ def unstack_fill_nan(
       the original shape of the dataset that should have been store in the latitude
       attributes by `stack_drop_nans` and the global attributes 'cat:domain'.
       It is recommended to fill this argument in the config. Ex:
-      .. code-block:: yaml
 
           utils:
             stack_drop_nans:

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -131,7 +131,7 @@ def stack_drop_nans(
     if to_file is not None:
         # set default path to store the information necessary to unstack
         # the name includes the domain and the original shape to uniquely identify the dataset
-        domain = ds.attrs.get("cat:domain", "unknown_domain")
+        domain = ds.attrs.get("cat:domain", "unknown")
         to_file = to_file.format(domain=domain, shape=original_shape)
         if not Path(to_file).parent.exists():
             os.mkdir(Path(to_file).parent)

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -97,7 +97,8 @@ def stack_drop_nans(
       If given a string with {shape} and {domain}, the formatting will fill them with
       the original shape of the dataset and the global attributes 'cat:domain'.
       If None (default), nothing is written to disk.
-      It is recommended to fill this argument in the config. Ex:
+      It is recommended to fill this argument in the config. It will be parsed automatically.
+      E.g.:
 
           utils:
             stack_drop_nans:
@@ -171,7 +172,8 @@ def unstack_fill_nan(
       If given a string with {shape} and {domain}, the formatting will fill them with
       the original shape of the dataset that should have been store in the latitude
       attributes by `stack_drop_nans` and the global attributes 'cat:domain'.
-      It is recommended to fill this argument in the config. Ex:
+      It is recommended to fill this argument in the config. It will be parsed automatically.
+      E.g.:
 
           utils:
             stack_drop_nans:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* ``xs.utils.stack_drop_nans``/ ``xs.utils.unstack_fill_nan``  format the `to_file`/`coords` string to add the domain and the initial shape. 
* The initial shape is added to the lat and lon attrs to be able to retrive it when it is time to unstack.
* Redifining lon and lat to fix bug in xarray (https://github.com/pydata/xarray/issues/6946)

### Does this PR introduce a breaking change?
I don't think so. If you pass a string without {domain} or {shape} as before, the formatting will be ignored.

### Other information:
