### PR TITLE
better detection of CMIP datasets for restrict_resolution

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * Small bugfixes in aggregate.py (:pull:`55`, :pull:`56`).
 * Default method of `xs.extract.resample` now depends on frequency. (:issue:`57`, :pull:`58`).
+* Bugfix for `_restrict_by_resolution` with CMIP6 datasets (:pull:`71`).
 
 v0.3.0 (2022-08-23)
 -------------------

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -802,7 +802,7 @@ def _restrict_by_resolution(catalogs: dict, id_columns: list, restrictions: str)
             logger.info(f"Dataset {i} appears to have multiple resolutions.")
 
             # For CMIP, the order is dictated by a list of grid labels
-            if pd.unique(df_sim["activity"])[0] == "CMIP":
+            if "MIP" in pd.unique(df_sim["activity"])[0]:
                 order = np.array([])
                 for d in domains:
                     match = [


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - No.
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* `restrict_resolution` now works with CMIP6 datasets.

### Does this PR introduce a breaking change?
No.

### Other information:
