### PR TITLE
Fix 70

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,7 @@ Internal changes
 * Small bugfixes in aggregate.py (:pull:`55`, :pull:`56`).
 * Default method of `xs.extract.resample` now depends on frequency. (:issue:`57`, :pull:`58`).
 * Bugfix for `_restrict_by_resolution` with CMIP6 datasets (:pull:`71`).
+* More complete check of coverage in ``_subset_file_coverage`` (:issue: `70`, :pull: `72`)
 
 v0.3.0 (2022-08-23)
 -------------------

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -316,20 +316,6 @@ def extract_dataset(
                         catalog[key].df["xrfreq"].iloc[0]
                         == variables_and_freqs[var_name]
                     ):
-                        # test
-                        if True:
-                            counts = da.time.resample(time=xrfreq).count()
-                            if any(counts > 1):
-                                raise ValueError(
-                                    "Dataset is labelled as having a sampling frequency of "
-                                    f"{xrfreq}, but some periods have more than one data point."
-                                )
-                            if any(counts.isnull()):
-                                raise ValueError(
-                                    "The resampling count contains nans. There might be missing data"
-                                )
-                            da["time"] = counts.time
-                        # test
                         ds = ds.assign({var_name: da})
                     else:
                         raise ValueError(

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import re
-import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Callable, List, Optional, Union
@@ -999,7 +998,7 @@ def _subset_file_coverage(
 
         # Very rough guess of the coverage relative to the requested period,
         # without having to open the files or checking day-by-day
-        # This is only checking that you have the first and last time point, not that you have everything in between!!
+        # This is only checking that you have the first and last time point, not that you have everything in between.
         guessed_nb_hrs = np.min(
             [
                 df[files_in_range]["date_end"].max(),


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #70 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* A more complete check of the file coverage in search. The previous test was only checking that the beginning and end of the period were present in the selected files. I added a test that counts the sum of hours in each files (according to date_start and date_end) and compares it to the amount of hours that should be in the given period (at the given coverage level, 0.99).

### Does this PR introduce a breaking change?
Yes, `search_data_catalogs` will not return dataset with large  holes in the data.

### Other information:

We also need a check in `extract_dataset`. I suggested something in PR #68 based on the new argument `ensure_correct_time`.