### PR TITLE
Fix unstack mistake

### DIFF
--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -215,9 +215,9 @@ def unstack_fill_nan(
         if isinstance(coords, (str, os.PathLike)):
             # find original shape in the attrs of one of the dimension
             original_shape = "unknown"
-            for dim in ds.dims:
-                if "original_shape" in ds[dim].attrs:
-                    original_shape = ds[dim].attrs["original_shape"]
+            for c in ds.coords:
+                if "original_shape" in ds[c].attrs:
+                    original_shape = ds[c].attrs["original_shape"]
             domain = ds.attrs.get("cat:domain", "unknown")
             coords = coords.format(domain=domain, shape=original_shape)
             logger.info(f"Dataset unstacked using {coords}.")

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -216,7 +216,7 @@ def unstack_fill_nan(
             # find original shape in the attrs of one of the dimension
             original_shape = "unknown"
             for dim in ds.dims:
-                if "original_shape" in dim.attrs:
+                if "original_shape" in ds[dim].attrs:
                     original_shape = ds[dim].attrs["original_shape"]
             domain = ds.attrs.get("cat:domain", "unknown")
             coords = coords.format(domain=domain, shape=original_shape)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*I made a mistake. `unstack` should be looking at the coords not the dims to find the original_shape attrs. There was an issue with my deployment on doris so my tests were still looking at the lat/lon dependent version, oups!

### Does this PR introduce a breaking change?


### Other information:
