### PR TITLE
Accelerate catalog parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,7 @@ New features and enhancements
     * Allow passing skipna to the regridder kwargs.
     * Do not fail for any grid mapping problem, includin if a grid_mapping attribute mentions a variable that doesn't exist.
 * Default email sent to the local user. (:pull:`68`).
+* Special accelerated pathway for parsing catalogs with all dates within the datetime64[ns] range (:pull:`75`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
The default "read csv kwargs" not contain a special function for parsing `date_start` and  `date_end`. Instead of directly parsing from string to period (and element by element), this function parses the whole array to a `DatetimeIndex` which it then converts to a `PeriodIndex`. If an `OutOfBoundsDatetime` error is raised, it switches back to parsing the dates with `PeriodIndex` directly.

If the direct-period version is used, a warning is issued, so the user knows they have time to go and get an orange juice.

### Does this PR introduce a breaking change?
No.

### Other information:
Parsing strings with `Period` and `PeriodIndex` is ridiculously slow. See for yourselves:

- The complete "simulations" catalog, 95 000 entries, with some dates after 2262-04-12, thus it must use the direct-period method (similar to before this PR): 50 s is spent converting the dates.
- The MRCC5 C series catalog, 950 000 entries (10x more), all dates within the `datetime64[ns]` range : 0.7 s.

I think I may raise the issue to pandas. But for now, we have a way around.

EDIT: Oops, I forgot that, but this also adds an error catch and logging call for some errors I got in `name_parser`.