### PR TITLE
simpler way to create a new catalog

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,7 +31,7 @@ New features and enhancements
 * New function `catalog.unstack_id` to reverse-engineer IDs. (:pull:`63`).
 * `generate_id` now accepts Datasets. (:pull:`63`).
 * Add `rechunk` option to `properties_and_measures` (:pull:`76`).
-* Add `create` argument to `ProjectCatalog` (:pull:`77`).
+* Add `create` argument to `ProjectCatalog` (:issue:`11`, :pull:`77`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,7 @@ New features and enhancements
 * New function `catalog.unstack_id` to reverse-engineer IDs. (:pull:`63`).
 * `generate_id` now accepts Datasets. (:pull:`63`).
 * Add `rechunk` option to `properties_and_measures` (:pull:`76`).
+* Add `create` argument to `ProjectCatalog` (:pull:`77`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -410,7 +410,38 @@ class ProjectCatalog(DataCatalog):
 
         return cls(str(meta_path))
 
-    def __init__(self, df, *args, create=False, overwrite=None, project=None, **kwargs):
+    def __init__(
+        self,
+        df: Union[str, dict],
+        *args,
+        create: bool = False,
+        overwrite: bool = None,
+        project: dict = None,
+        **kwargs,
+    ):
+        """
+        Open or create a project catalog.
+
+        Parameters
+        ----------
+        df : PathLike, dict
+          If string, this must be a path or URL to a catalog JSON file.
+          If dict, this must be a dict representation of an ESM catalog.  See the notes below.
+        create: bool
+          If True, and if 'df' is a string, this will create an empty ProjectCatalog if none already exists.
+        project : dict-like
+          Metadata to create the catalog, if required.
+        overwrite : bool
+          If this and 'create' are True, this will overwrite any existing JSON and CSV file with an empty catalog.
+
+        Notes
+        ----------
+        The dictionary in 'df' must have two keys: ‘esmcat’ and ‘df’.
+        The ‘esmcat’ key must be a dict representation of the ESM catalog. This should follow the template used by xscen.catalog.esm_col_data.
+        The ‘df’ key must be a Pandas DataFrame containing content that would otherwise be in the CSV file.
+
+
+        """
         if create:
             if isinstance(df, (str, Path)) and (
                 not os.path.isfile(Path(df)) or overwrite

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -411,12 +411,13 @@ class ProjectCatalog(DataCatalog):
         return cls(str(meta_path))
 
     def __init__(self, df, *args, **kwargs):
-        if "create" in kwargs:
+        if kwargs.get("create", None):
             kwargs.pop("create")
             if isinstance(df, (str, Path)) and (
                 not os.path.isfile(Path(df)) or kwargs.get("overwrite", None) is True
             ):
                 self.create(df, **kwargs)
+        kwargs.pop("create", None)
         kwargs.pop("project", None)
         kwargs.pop("overwrite", None)
         super().__init__(df, *args, **kwargs)

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -416,7 +416,14 @@ class ProjectCatalog(DataCatalog):
             if isinstance(df, (str, Path)) and (
                 not os.path.isfile(Path(df)) or kwargs.get("overwrite", None) is True
             ):
-                self.create(df, **kwargs)
+                self.create(
+                    df,
+                    **{
+                        key: kwargs[key]
+                        for key in ["project", "overwrite"]
+                        if key in kwargs
+                    },
+                )
         kwargs.pop("create", None)
         kwargs.pop("project", None)
         kwargs.pop("overwrite", None)

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -411,6 +411,14 @@ class ProjectCatalog(DataCatalog):
         return cls(str(meta_path))
 
     def __init__(self, df, *args, **kwargs):
+        if "create" in kwargs:
+            kwargs.pop("create")
+            if isinstance(df, (str, Path)) and (
+                not os.path.isfile(Path(df)) or kwargs.get("overwrite", None) is True
+            ):
+                self.create(df, **kwargs)
+        kwargs.pop("project", None)
+        kwargs.pop("overwrite", None)
         super().__init__(df, *args, **kwargs)
         self.check_valid()
         self.drop_duplicates()

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -410,23 +410,12 @@ class ProjectCatalog(DataCatalog):
 
         return cls(str(meta_path))
 
-    def __init__(self, df, *args, **kwargs):
-        if kwargs.get("create", None):
-            kwargs.pop("create")
+    def __init__(self, df, *args, create=False, overwrite=None, project=None, **kwargs):
+        if create:
             if isinstance(df, (str, Path)) and (
-                not os.path.isfile(Path(df)) or kwargs.get("overwrite", None) is True
+                not os.path.isfile(Path(df)) or overwrite
             ):
-                self.create(
-                    df,
-                    **{
-                        key: kwargs[key]
-                        for key in ["project", "overwrite"]
-                        if key in kwargs
-                    },
-                )
-        kwargs.pop("create", None)
-        kwargs.pop("project", None)
-        kwargs.pop("overwrite", None)
+                self.create(df, project=project, overwrite=overwrite)
         super().__init__(df, *args, **kwargs)
         self.check_valid()
         self.drop_duplicates()


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #11
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds a `create` argument to `ProjectCatalog()`:
  * `ProjectCatalog("path.json", create=True, project=project, overwrite=False)` (default) will only create a new catalog if one doesn't already exist. If it exists, it will drop the creation-specific kwargs and open the JSON normally.
  *  `ProjectCatalog("path.json", create=True, project=project, overwrite=True)` will create a new catalog, overwriting if necessary.
  * Any version without `create` will work as previously and crash if the file doesn't exist.

### Does this PR introduce a breaking change?

No.

### Other information:
