### PR TITLE
Fix 102

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,26 @@
 History
 =======
 
+v0.5.0 (unreleased)
+-------------------
+Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`) and Pascal Bourgault (:user:`aulemahal`).
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+
+Bug fixes
+^^^^^^^^^
+* ``clean_up`` now converts the calendar of variables that use "interpolate" in "missinge_by_var" at the same time.
+Hence, when it is a conversion from a 360_day calendar, the random date are the same of the these variables. (:issue:`102`, :pull:`104`)
+
+Internal changes
+^^^^^^^^^^^^^^^^
+
+
 v0.4.0 (2022-09-28)
 -------------------
 Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`) and Pascal Bourgault (:user:`aulemahal`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,6 @@ Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliet
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
@@ -20,7 +19,6 @@ Hence, when it is a conversion from a 360_day calendar, the random date are the 
 
 Internal changes
 ^^^^^^^^^^^^^^^^
-
 
 v0.4.0 (2022-09-28)
 -------------------

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -539,7 +539,9 @@ def clean_up(
         # if missing_by_var exist make sure missing data are added to time axis
         if missing_by_var:
             if not all(k in missing_by_var.keys() for k in ds.data_vars):
-                raise ValueError("All variables must be in 'missing_by_var' if using this option.")
+                raise ValueError(
+                    "All variables must be in 'missing_by_var' if using this option."
+                )
             convert_calendar_kwargs["missing"] = -9999
 
         # make default `align_on`='`random` when the initial calendar is 360day

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -557,7 +557,9 @@ def clean_up(
                     ds_with_nan = ds[var].where(ds[var] != -9999)
                     converted_var = ds_with_nan.interpolate_na("time", method="linear")
                 else:
-                    converted_var = xr.where(ds[var] == -9999, missing, ds[var])
+                    converted_var = xr.where(
+                        ds[var] != -9999, ds[var], missing, keep_attrs=True
+                    )
                 ds[var] = converted_var
 
     # unstack nans

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -538,7 +538,9 @@ def clean_up(
 
         # if missing_by_var exist make sure missing data are added to time axis
         if missing_by_var:
-            convert_calendar_kwargs.setdefault("missing", -9999)
+            if not all(k in missing_by_var.keys() for k in ds.data_vars):
+                raise ValueError("All variables must be in 'missing_by_var' if using this option.")
+            convert_calendar_kwargs["missing"] = -9999
 
         # make default `align_on`='`random` when the initial calendar is 360day
         if get_calendar(ds) == "360_day" and "align_on" not in convert_calendar_kwargs:

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -561,9 +561,9 @@ def clean_up(
                     ds_with_nan = ds[var].where(ds[var] != -9999)
                     converted_var = ds_with_nan.interpolate_na("time", method="linear")
                 else:
-                    converted_var = xr.where(
-                        ds[var] != -9999, ds[var], missing, keep_attrs=True
-                    )
+                    var_attrs = ds[var].attrs
+                    converted_var = xr.where(ds[var] == -9999, missing, ds[var])
+                    converted_var.attrs = var_attrs
                 ds[var] = converted_var
 
     # unstack nans

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -554,12 +554,7 @@ def clean_up(
             for var, missing in missing_by_var.items():
                 logging.info(f"Filling missing {var} with {missing}")
                 if missing == "interpolate":
-                    converted_var = convert_calendar(
-                        ds_copy[var], **convert_calendar_kwargs, missing=np.nan
-                    )
-                    converted_var = converted_var.interpolate_na(
-                        "time", method="linear"
-                    )
+                    converted_var = ds[var].interpolate_na("time", method="linear")
                 else:
                     ocean_var = ds_copy[var].isnull().all("time")
                     converted_var = convert_calendar(

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -554,7 +554,7 @@ def clean_up(
             for var, missing in missing_by_var.items():
                 logging.info(f"Filling missing {var} with {missing}")
                 if missing == "interpolate":
-                    ds_with_nan = xr.where(ds[var] == -9999, np.nan, ds[var])
+                    ds_with_nan = ds[var].where(ds[var] != -9999)
                     converted_var = ds_with_nan.interpolate_na("time", method="linear")
                 else:
                     converted_var = xr.where(ds[var] == -9999, missing, ds[var])


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #102 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Instead of re-converting the calendar for each variable individually, use the conversion that was done on the whole dataset pour variable that interpolate over missing dates.
* fixes #102 

### Does this PR introduce a breaking change?
not sure? The conversion will be done at the same time for many variables instead of one at the time. Hence, the dates that are interpolated over will be the same for all variables, instead of being different for all variables. So, you can't reproduce the old result. But it was already impossible to reproduce it exactly because the dates are random. 

### Other information:
