### PR TITLE
Minor fixes following ESPO-R5's diagnostics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliet
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* New "timeout_cleanup" option for ``save_to_zarr``, which removes variables that were in the process of being written when receiving a ``TimeoutException``. (:pull:`106`).
+* New ``scripting.skippable`` context, allowing the use of CTRL-C to skip code sections. (:pull:`106`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -16,6 +18,7 @@ Bug fixes
 ^^^^^^^^^
 * ``clean_up`` now converts the calendar of variables that use "interpolate" in "missing_by_var" at the same time.
 Hence, when it is a conversion from a 360_day calendar, the random dates are the same for all of the these variables. (:issue:`102`, :pull:`104`)
+* ``properties_and_measures`` no longer casts month coordinates to string (:pull:`106`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/config.py
+++ b/xscen/config.py
@@ -156,12 +156,12 @@ def parse_config(func_or_cls):
         sig = inspect.signature(func)
         if CONFIG.get("print_it_all"):
             logger.debug(f"For func {func}, found config {from_config}.")
-            logger.debug("Original kwargs :", kwargs)
+            logger.debug(f"Original kwargs : {kwargs}")
         for k, v in from_config.items():
             if k in sig.parameters:
                 kwargs.setdefault(k, v)
         if CONFIG.get("print_it_all"):
-            logger.debug("Modified kwargs :", kwargs)
+            logger.debug(f"Modified kwargs : {kwargs}")
 
         return func(*args, **kwargs)
 

--- a/xscen/diagnostics.py
+++ b/xscen/diagnostics.py
@@ -244,8 +244,6 @@ def properties_and_measures(
         # to be able to save in zarr, convert object to string
         if "season" in ds1:
             ds1["season"] = ds1.season.astype("str")
-        if "month" in ds1:
-            ds1["month"] = ds1.month.astype("str")
 
     prop.attrs["cat:processing_level"] = to_level_prop
     meas.attrs["cat:processing_level"] = to_level_meas

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -527,7 +527,7 @@ def search_data_catalogs(
     match_hist_and_fut: bool, optional
       If True, historical and future simulations will be combined into the same line, and search results lacking one of them will be rejected.
     periods : list
-      [start, end] of the period to be evaluated (or a list of lists)
+      [start, end] of the period to be evaluated (or a list of lists).
     id_columns : list, optional
       List of columns used to create a id column. If None is given, the original
       "id" is left.
@@ -1062,14 +1062,15 @@ def _subset_file_coverage(
         else:
             guessed_nb_hrs_sum = period_nb_hrs
 
-        # 'coverage' adds some leeway, for example to take different calendars into account or missing 2100-12-31
         if (
             guessed_nb_hrs / period_nb_hrs < coverage
             or len(df[files_in_range]) == 0
             or guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos < coverage
         ):
             logging.warning(
-                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage."
+                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage "
+                f"({guessed_nb_hrs / period_nb_hrs}, {len(df[files_in_range])}, "
+                f"{guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos}."
             )
             return pd.DataFrame(columns=df.columns)
 

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -1070,9 +1070,10 @@ def _subset_file_coverage(
             or guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos < coverage
         ):
             logging.warning(
-                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage "
-                f"({guessed_nb_hrs / period_nb_hrs}, {len(df[files_in_range])}, "
-                f"{guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos}."
+                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage."
+                f"% covered, min to max : {guessed_nb_hrs / period_nb_hrs:.1%}, "
+                f"% covered, sum of hours : {guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos:.1%}, "
+                f"number of files in range : {len(df[files_in_range])}."
             )
             return pd.DataFrame(columns=df.columns)
 

--- a/xscen/io.py
+++ b/xscen/io.py
@@ -13,6 +13,7 @@ from rechunker import rechunk as _rechunk
 from xclim.core.calendar import get_calendar
 
 from .config import parse_config
+from .scripting import TimeoutException, timeout
 from .utils import translate_time_chunk
 
 logger = logging.getLogger(__name__)
@@ -358,6 +359,7 @@ def save_to_zarr(
     encoding: dict = None,
     mode: str = "f",
     itervar: bool = False,
+    timeout_cleanup: bool = False,
 ) -> None:
     """
     Saves a Dataset to Zarr, rechunking if requested.
@@ -385,6 +387,10 @@ def save_to_zarr(
     itervar : bool
       If True, (data) variables are written one at a time, appending to the zarr.
       If False, this function computes, no matter what was passed to kwargs.
+    timeout_cleanup : bool
+      If True and a :py:class:`xscen.scripting.TimeoutException` is raised during the writing,
+      the variable being written is removed from the dataset as it is incomplete.
+      This does nothing if `compute` is False.
 
     Returns
     -------
@@ -481,17 +487,33 @@ def save_to_zarr(
         for i, (name, var) in enumerate(ds.data_vars.items()):
             logger.debug(f"Writing {name} ({i + 1} of {len(ds.data_vars)}) to {path}")
             dsvar = ds.drop_vars(allvars - {name})
-            dsvar.to_zarr(
-                path,
-                mode="a",
-                encoding={k: v for k, v in (encoding or {}).items() if k in dsvar},
-                **zarr_kwargs,
-            )
+            try:
+                dsvar.to_zarr(
+                    path,
+                    mode="a",
+                    encoding={k: v for k, v in (encoding or {}).items() if k in dsvar},
+                    **zarr_kwargs,
+                )
+            except TimeoutException:
+                if timeout_cleanup:
+                    logger.info(f"Removing incomplete {name}.")
+                    sh.rmtree(path / name)
+                raise
+
     else:
         logger.debug(f"Writing {list(ds.data_vars.keys())} for {filename}.")
-        return ds.to_zarr(
-            filename, compute=compute, mode="a", encoding=encoding, **zarr_kwargs
-        )
+        try:
+            return ds.to_zarr(
+                filename, compute=compute, mode="a", encoding=encoding, **zarr_kwargs
+            )
+        except TimeoutException:
+            if timeout_cleanup:
+                logger.info(
+                    f"Removing incomplete {list(ds.data_vars.keys())} for {filename}."
+                )
+                for name in ds.data_vars:
+                    sh.rmtree(path / name)
+            raise
 
 
 @parse_config

--- a/xscen/io.py
+++ b/xscen/io.py
@@ -13,7 +13,7 @@ from rechunker import rechunk as _rechunk
 from xclim.core.calendar import get_calendar
 
 from .config import parse_config
-from .scripting import TimeoutException, timeout
+from .scripting import TimeoutException
 from .utils import translate_time_chunk
 
 logger = logging.getLogger(__name__)
@@ -359,7 +359,7 @@ def save_to_zarr(
     encoding: dict = None,
     mode: str = "f",
     itervar: bool = False,
-    timeout_cleanup: bool = False,
+    timeout_cleanup: bool = True,
 ) -> None:
     """
     Saves a Dataset to Zarr, rechunking if requested.
@@ -388,7 +388,7 @@ def save_to_zarr(
       If True, (data) variables are written one at a time, appending to the zarr.
       If False, this function computes, no matter what was passed to kwargs.
     timeout_cleanup : bool
-      If True and a :py:class:`xscen.scripting.TimeoutException` is raised during the writing,
+      If True (default) and a :py:class:`xscen.scripting.TimeoutException` is raised during the writing,
       the variable being written is removed from the dataset as it is incomplete.
       This does nothing if `compute` is False.
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* New "timeout_cleanup" option for ``save_to_zarr``, which removes variables that were in the process of being written when receiving a ``TimeoutException``. (:pull:`106`).
* New ``scripting.skippable`` context, allowing the use of CTRL-C to skip code sections. (:pull:`106`)
* * ``properties_and_measures`` no longer casts month coordinates to string (:pull:`106`).
* Fixed `parse_config`. There is a very special option that logs what args were parsed from the config. The log calls have been fixed,
* Added a bit more information in the "insufficient coverage" log warning.

### Does this PR introduce a breaking change?
No.

### Other information:
These changes are the ones I used to help me run my "properties and diagnostics" script for ESPO-R5. Forget the branch name it is meaningless.