### PR TITLE
Exclude vars from catalogs in parse_directory

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliet
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Possibility of excluding variables read from file from the catalog produced by ``parse_directory``. (:pull:`107`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -883,6 +883,7 @@ def parse_directory(
         Dictionary with mapping from parsed name to controlled names for each column.
         May have an additionnal "attributes" entry which maps from attribute names in the files to
         official column names. The attribute translation is done before the rest.
+        In the "variable" entry, if a name is mapped to None (null), that variable will not be listed in the catalog.
     xr_open_kwargs: dict
         If needed, arguments to send xr.open_dataset() when opening the file to read the attributes.
     parallel_depth: int
@@ -1014,8 +1015,12 @@ def parse_directory(
             # Variable can be a tuple, we still want to replace individual names through the cvs
             df["variable"] = df.variable.apply(
                 lambda vs: vs
-                if isinstance(vs, str)
-                else tuple(cvs["variable"].get(v, v) for v in vs)
+                if isinstance(vs, str) or pd.isnull(vs)
+                else tuple(
+                    cvs["variable"].get(v, v)
+                    for v in vs
+                    if cvs["variable"].get(v, v) is not None
+                )
             )
 
     # translate xrfreq into frequencies and vice-versa


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

In the "variable" mapping passed to `cvs` in `parse_directory`, mapping a var name to `None` will exclude that var from the catalog. Meaning it won't appear in the `variable column. The file entry is untouched.
This is useful when one is reading the variables from the files (using `read_from_file`). It allows excluding things like `time_bnds`.

Another technique would have been passing `drop_variables` to `xr_open_kwargs`, but this is not universal as the optimization will use `netCDF4` or `zarr` to open the files when they can.


### Does this PR introduce a breaking change?
No.

### Other information:
@mccrayc 