### PR TITLE
Regrid's weights location as kwarg

### DIFF
--- a/xscen/regrid.py
+++ b/xscen/regrid.py
@@ -24,9 +24,9 @@ __all__ = ["regrid_dataset", "create_mask"]
 @parse_config
 def regrid_dataset(
     ds: xr.Dataset,
-    weights_location: Union[str, PosixPath],
     ds_grid: xr.Dataset,
     *,
+    weights_location: Union[str, PosixPath],
     regridder_kwargs: Optional[dict] = None,
     intermediate_grids: Optional[dict] = None,
     to_level: str = "regridded",

--- a/xscen/regrid.py
+++ b/xscen/regrid.py
@@ -25,8 +25,8 @@ __all__ = ["regrid_dataset", "create_mask"]
 def regrid_dataset(
     ds: xr.Dataset,
     ds_grid: xr.Dataset,
-    *,
     weights_location: Union[str, PosixPath],
+    *,
     regridder_kwargs: Optional[dict] = None,
     intermediate_grids: Optional[dict] = None,
     to_level: str = "regridded",


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* In `regrid_dataset`, moves `weights_location` to the keyword argument section.

### Does this PR introduce a breaking change?
Yes, script using positional arguments for this function will break.

### Other information:
As a kwarg it can be included in the config, but I may have missed something?