### PR TITLE
fix 122

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -29,6 +29,7 @@ Hence, when it is a conversion from a 360_day calendar, the random dates are the
 * Added missing `parse_config` to functions in `reduce.py` (:pull:`92`).
 * Added deepcopy before `skipna` is popped in `spatial_mean` (:pull:`92`).
 * `subset_warming_level` now validates that the data exists in the dataset provided (:issue:`117`, :pull:`119`).
+* Adapt `stack_drop_nan` for the newest version of xarray (2022.12.0). (:issue:`122`, :pull:`126`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -122,11 +122,7 @@ def stack_drop_nans(
     original_shape = "x".join(map(str, mask.shape))
 
     mask_1d = mask.stack({new_dim: mask.dims})
-    out = (
-        ds.stack({new_dim: mask.dims})
-        .where(mask_1d, drop=True)
-        .reset_index(new_dim, drop=True)
-    )
+    out = ds.stack({new_dim: mask.dims}).where(mask_1d, drop=True).reset_index(new_dim)
     for dim in mask.dims:
         out[dim].attrs.update(ds[dim].attrs)
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] `pre-commit` hooks are installed/active in my local clone (`$ pre-commit install`)
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #122 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] If a merge request has been made in parallel to this PR in xscen-notebooks, it is merged and the submodules have been updated.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adjust `stack_drop_nan` to new version of xarray.

### Does this PR introduce a breaking change?
No, this returns the same thing as with the previous version of xarray.

### Other information:
 With the new version of xarray, lat and lon were dropped out of `out` on l.125 of utils. I removed `drop-=True` to recover the previous behaviour of keeping them as coordinates only.