### PR TITLE
add restrict_wl

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ New features and enhancements
 * New ``utils.show_versions`` function for printing or writing to file the dependency versions of `xscen`. (:issue:`109`, :pull:`112`).
 * Added previously private notebooks to the documentation. (:pull:`108`).
 * Notebooks are now tested using `pytest` with `nbval`. (:pull:`108`).
+* New ``restrict_wl`` argument for ``extract.search_data_catalogs`` to filter dataset that are not in the warming level csv. (:issue:`105`, :pull:`138`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@ New features and enhancements
 * New ``utils.show_versions`` function for printing or writing to file the dependency versions of `xscen`. (:issue:`109`, :pull:`112`).
 * Added previously private notebooks to the documentation. (:pull:`108`).
 * Notebooks are now tested using `pytest` with `nbval`. (:pull:`108`).
-* New ``restrict_wl`` argument for ``extract.search_data_catalogs`` to filter dataset that are not in the warming level csv. (:issue:`105`, :pull:`138`).
+* New ``restrict_warming_level`` argument for ``extract.search_data_catalogs`` to filter dataset that are not in the warming level csv. (:issue:`105`, :pull:`138`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -551,7 +551,7 @@ def search_data_catalogs(
         Used to restrict the results to a given number of members for a given simulation.
         Currently only supports {"ordered": int} format.
     restrict_warming_level : bool,dict
-        Used to restrict the results to only datasets that exist in the csv used to compute warming levels.
+        Used to restrict the results to only datasets that exist in the csv used to compute warming levels in `subset_warming_level`.
         If True, this will only keep the datasets that have a mip_era, source, experiment
         and member combination that exist in the csv. This does not guarantees that a given warming level will be reached, only that the datasets have corresponding columns in the csv.
         More option can be added by passing a dictionary instead of a boolean.


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*  new argument to restrict the datasets to only ones that exist in the warming level csv. 
*  `subset_warming_level` fails if the dataset doesn't exist. Hence, filtering beforehand is necessary.
* It is possible to pass a boolean or a dictionnary with arguments similar to `subset_warming_level` (ignore_member and tas_csv).

### Does this PR introduce a breaking change?
 no

### Other information:
