### PR TITLE
Uniformize environments and update dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,10 +19,15 @@
 # absolute, like shown here.
 #
 import os
-import warnings
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath('..'))
+if os.environ.get('READTHEDOCS') and 'ESMFMKFILE' not in os.environ:
+    # RTD doesn't activate the env, and esmpy depends on a env var set there
+    # We assume the `os` package is in {ENV}/lib/pythonX.X/os.py
+    # See conda-forge/esmf-feedstock#91 and readthedocs/readthedocs.org#4067
+    os.environ['ESMFMKFILE'] = str(Path(os.__file__).parent.parent / 'esmf.mk')
 
 import xscen  # noqa
 import xarray  # noqa

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,32 +5,33 @@ dependencies:
   # Don't forget to sync the changes here with environment.yml!
   # Some pins here are meant to accelerate conda and might not be related to real needs
   # Main packages
+  - cartopy
   - cftime
   - clisops
-  - xarray
-  - xclim >=0.37
-  - xesmf >=0.6.3
-  # 2022-12-12: ESMpy 8.3.1 and 8.4.0 are incompatible with newest xesmf
-  - esmpy <=8.2
   - dask
+  - fsspec
   - geopandas
-  - pandas
-  - rechunker
-  - shapely
-  - pyyaml
+  - h5netcdf
   - intake
   - intake-esm >=2022.9.18
-  # This ensures that the correct numpy is installed as of 2022-07-15.
-  - numba >=0.55.2
-  # Plotting
-  - cartopy
   - matplotlib
-  - nc-time-axis >=1.3.1
-  # IO
-  - h5netcdf
   - netCDF4
-  - pyarrow >=1.0.0  # For lighter in-memory catalogs
+  - numpy
+  - pandas
+  - pyyaml
+  - rechunker
+  - shapely
+  - xarray
+  - xclim >=0.37
+  - xesmf >=0.7
   - zarr
+  # To avoid bugs
+  # See https://github.com/esmf-org/esmf/issues/115
+  # we add this "dependency" so the following pip install doesn't install anything else than xscen
+  - pytest-json-report
+  # Opt
+  - nc-time-axis >=1.3.1
+  - pyarrow >=1.0.0  # For lighter in-memory catalogs
   # Dev
   - bumpversion
   - ipykernel

--- a/environment.yml
+++ b/environment.yml
@@ -1,34 +1,35 @@
 name: xscen
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python >=3.8
-  # FIXME: These entries require versions
   # Don't forget to sync the changes here with environment-dev.yml!
   # Main packages
+  - cartopy
   - cftime
   - clisops
   - dask
-  # 2022-12-12: ESMpy 8.3.1 and 8.4.0 are incompatible with newest xesmf
-  - esmpy <=8.2
+  - fsspec
   - geopandas
+  - h5netcdf
+  - intake
+  - intake-esm >=2022.9.18
+  - matplotlib
+  - netCDF4
+  - numpy
   - pandas
+  - pyyaml
   - rechunker
   - shapely
   - xarray
   - xclim >=0.37
-  - xesmf >=0.6.2
-  - pyyaml
-  - intake
-  - intake-esm >=2022.9.18
-  # Plotting
-  - cartopy
-  - matplotlib
-  - nc-time-axis >=1.3.1
-  # IO
-  - h5py
-  - netCDF4
-  - pyarrow
+  - xesmf >=0.7
   - zarr
+  # To avoid bugs
+  # See https://github.com/esmf-org/esmf/issues/115
+  # we add this "dependency" so the following pip install doesn't install anything else than xscen
+  - pytest-json-report
+  # Opt
+  - nc-time-axis >=1.3.1
+  - pyarrow >=1.0.0
   - pip

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "dask",
     "fsspec",
     "geopandas",
-    "h5py",
+    "h5netcdf",
     "intake",
     "intake-esm>=2022.9.18",
     "matplotlib",
@@ -43,7 +43,7 @@ requirements = [
     "shapely",
     "xarray",
     "xclim>=0.37",
-    "xesmf>=0.6.2",  # This is not available on pypi.
+    "xesmf>=0.7",  # This is not available on pypi.
     "zarr",
 ]
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Reorder the `environment` files to fit what's in  `setup.py` (an alphabetical order)
* Remove fixes for esmpy 8.4, as xESMF 0.7 takes care of that (the pin is bumped).
* Add a (brand new!) fix for esmpy 8.4 to avoid installing packages with pip with running `pip install -e .`  on xscen
* Remove `numba` for the envs, it is not a direct dep and the bug related to version 0.55 is caduc with 0.56.
* Uniformize the two envs : h5netcdf, pyarrow, fsspec

### Does this PR introduce a breaking change?
No.

### Other information:
This still install `netCDF4` 1.6.2, I'm not sure if  this version has been fixed or not?