### PR TITLE
fix for functions with decorators in Pycharm 2022

### DIFF
--- a/xscen/config.py
+++ b/xscen/config.py
@@ -185,7 +185,7 @@ def parse_config(func_or_cls):  # noqa: D103
     if isinstance(func_or_cls, type):
         func_or_cls.__init__ = _wrapper
         return func_or_cls
-    _wrapper: func_or_cls
+    _wrapper: func_or_cls  # Fix a decorator bug in Pycharm 2022
     return _wrapper
 
 

--- a/xscen/config.py
+++ b/xscen/config.py
@@ -185,6 +185,7 @@ def parse_config(func_or_cls):  # noqa: D103
     if isinstance(func_or_cls, type):
         func_or_cls.__init__ = _wrapper
         return func_or_cls
+    _wrapper: func_or_cls
     return _wrapper
 
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* This fixes a bug in Pycharm 2022 CE, where hints for decorated functions are reduced to `(*args, **kwargs)` instead of actual relevant information. This bug is quite annoying, since this is 90% of `xscen`.
* Issue on JetBrains: https://youtrack.jetbrains.com/issue/PY-48338
* The fix was taken from here (without the need to install that package): https://pypi.org/project/decohints/ 

### Does this PR introduce a breaking change?

Probably not? @aulemahal is the one who understands `config.py` 😅 
