### PR TITLE
Fix unstack_time for dataset with vars without time.

### DIFF
--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -853,12 +853,12 @@ def unstack_dates(
         )
         new_shape = [len(new_coords[d]) for d in new_dims]
         # Use dask or numpy's algo.
-        return xr.DataArray(da.data.reshape(new_shape), dims=new_dims)
 
-    if uses_dask(ds):
-        # This is where it happens. Flox will minimally rechunk
-        # so the reshape operation can be performed blockwise
-        dsp = flox.xarray.rechunk_for_blockwise(dsp, "time", years)
+        if uses_dask(da):
+            # This is where it happens. Flox will minimally rechunk
+            # so the reshape operation can be performed blockwise
+            da = flox.xarray.rechunk_for_blockwise(da, "time", years)
+        return xr.DataArray(da.data.reshape(new_shape), dims=new_dims)
 
     if isinstance(ds, xr.Dataset):
         dso = dsp.map(reshape_da, keep_attrs=True)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Minor fix: move the `flox` call so that it is only called on variables with a time dimension. Previously, if a dataset was being given, it would fail if at least one chunked variable didn't have a "time" dimension.

### Does this PR introduce a breaking change?
No.


### Other information:
