### PR TITLE
Support searching for multiple frequencies and for searching periods within .search()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,12 +18,15 @@ New features and enhancements
 * Add function ``regrid.create_bounds_rotated_pole`` and automatic use in ``regrid_dataset`` and ``spatial_mean``. This is temporary, while we wait for a functionning method in ``cf_xarray``. (:pull:`174`, :issue:`96`).
 * Add ``spatial`` submodule with functions ``creep_weights`` and ``creep_fill`` for filling NaNs using neighbours. (:pull:`174`).
 * Allow passing ``GeoDataFrame`` instances in ``spatial_mean``'s ``region`` argument, not only geospatial file paths. (:pull:`174`).
+* Allow searching for periods in `catalog.search`. (:issue:`123`, :pull:`170`).
+* Allow searching and extracting multiple frequencies for a given variable. (:issue:`168`, :pull:`170`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * 'mean' averaging has been deprecated in `spatial_mean`. (:pull:`125`).
 * 'interp_coord' has been renamed to 'interp_centroid' in `spatial_mean`. (:pull:`125`).
 * The 'datasets' dimension of the output of ``diagnostics.measures_heatmap`` is renamed 'realization'. (:pull:`167`).
+* `_subset_file_coverage` was renamed `subset_file_coverage` and moved to ``catalog.py`` to prevent circular imports. (:pull:`170`).
 
 Bug fixes
 ^^^^^^^^^
@@ -32,6 +35,8 @@ Bug fixes
 * ``compute_indicators`` no longer crashes if less than 3 timesteps are produced. (:pull:`125`).
 * `xarray` is temporarily pinned below v2023.3.0 due to an API-breaking change. (:issue:`175`, :pull:`173`).
 * `xscen.utils.unstack_fill_nan`` can now handle datasets that have non dimension coordinates. (:issue:`156`, :pull:`175`).
+* `extract_dataset` now skips a simulation way earlier if the frequency doesn't match. (:pull:`170`).
+* `extract_dataset` now correctly tries to extract in reverse timedelta order. (:pull:`170`).
 
 
 Internal changes
@@ -43,6 +48,7 @@ Internal changes
 * Added a few relevant `Shields <https://shields.io/>`_ to the README.rst. (:pull:`164`).
 * Better warning messages in ``_subset_file_coverage`` when coverage is insufficient. (:pull:`125`).
 * The top-level Makefile now includes a `linkcheck` recipe, and the ReadTheDocs configuration no longer reinstalls the `llvmlite` compiler library. (:pull:`173`).
+* The checkups on coverage and duplicates can now be skipped in `subset_file_coverage`. (:pull:`170`).
 
 v0.5.0 (2023-02-28)
 -------------------

--- a/docs/notebooks/1_catalog.ipynb
+++ b/docs/notebooks/1_catalog.ipynb
@@ -208,6 +208,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7f27214c-2524-4fb7-9b95-4a384ed13a53",
+   "metadata": {},
+   "source": [
+    "It is also possible to search for files that intersect a specific time period."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecda16b2-2d87-495d-b1e1-c2894b83fb1d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "DC.search(source=\"NorESM2.*\", periods=[[\"2016\", \"2017\"]]).unique(\n",
+    "    [\"date_start\", \"date_end\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "aa903092",
    "metadata": {},
    "source": [
@@ -278,8 +300,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xscen as xs\n",
-    "\n",
     "variables_and_freqs = {\"tas\": \"D\", \"pr\": \"3H\", \"sftlf\": \"fx\"}\n",
     "other_search_criteria = {\"institution\": [\"NOAA-GFDL\"], \"experiment\": [\"ssp585\"]}\n",
     "\n",
@@ -356,6 +376,42 @@
    "outputs": [],
    "source": [
     "cat_sim_adv[\"ScenarioMIP_NCC_NorESM2-MM_ssp585_r1i1p1f1_gn\"].unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "962a3c22-58f4-49c4-94ff-78d9c10bcc85",
+   "metadata": {},
+   "source": [
+    "It's also possible to search for multiple frequencies at the same time by using a list of xrfreq."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f79d33d-4687-416a-91e6-d4f37ea5efef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cat_sim_adv = xs.search_data_catalogs(\n",
+    "    data_catalogs=[f\"{Path().absolute()}/samples/pangeo-cmip6.json\"],\n",
+    "    variables_and_freqs={\"tas\": [\"D\", \"MS\", \"YS\"]},\n",
+    "    other_search_criteria={\n",
+    "        \"source\": [\"NorESM2-MM\"],\n",
+    "        \"processing_level\": [\"raw\"],\n",
+    "        \"experiment\": [\"ssp370\"],\n",
+    "    },\n",
+    "    match_hist_and_fut=True,\n",
+    "    allow_resampling=True,\n",
+    "    allow_conversion=True,\n",
+    ")\n",
+    "print(\n",
+    "    cat_sim_adv[\n",
+    "        \"ScenarioMIP_NCC_NorESM2-MM_ssp370_r1i1p1f1_gn\"\n",
+    "    ]._requested_variable_freqs\n",
+    ")"
    ]
   },
   {
@@ -594,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/1_catalog.ipynb
+++ b/docs/notebooks/1_catalog.ipynb
@@ -60,7 +60,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f25ee70d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -223,9 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "DC.search(source=\"NorESM2.*\", periods=[[\"2016\", \"2017\"]]).unique(\n",
-    "    [\"date_start\", \"date_end\"]\n",
-    ")"
+    "DC.search(periods=[[\"2016\", \"2017\"]]).unique([\"date_start\", \"date_end\"])"
    ]
   },
   {
@@ -267,7 +267,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "97d91cce",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import xscen as xs\n",
@@ -297,7 +299,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1958d406",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "variables_and_freqs = {\"tas\": \"D\", \"pr\": \"3H\", \"sftlf\": \"fx\"}\n",
@@ -326,7 +330,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a6e5bd7e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cat_sim[\"ScenarioMIP_NOAA-GFDL_GFDL-CM4_ssp585_r1i1p1f1_gr1\"].df"
@@ -346,7 +352,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9e30951b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cat_sim_adv = xs.search_data_catalogs(\n",
@@ -372,7 +380,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "29b2d3c5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cat_sim_adv[\"ScenarioMIP_NCC_NorESM2-MM_ssp585_r1i1p1f1_gn\"].unique()"
@@ -395,7 +405,7 @@
    },
    "outputs": [],
    "source": [
-    "cat_sim_adv = xs.search_data_catalogs(\n",
+    "cat_sim_adv_multifreq = xs.search_data_catalogs(\n",
     "    data_catalogs=[f\"{Path().absolute()}/samples/pangeo-cmip6.json\"],\n",
     "    variables_and_freqs={\"tas\": [\"D\", \"MS\", \"YS\"]},\n",
     "    other_search_criteria={\n",
@@ -408,7 +418,7 @@
     "    allow_conversion=True,\n",
     ")\n",
     "print(\n",
-    "    cat_sim_adv[\n",
+    "    cat_sim_adv_multifreq[\n",
     "        \"ScenarioMIP_NCC_NorESM2-MM_ssp370_r1i1p1f1_gn\"\n",
     "    ]._requested_variable_freqs\n",
     ")"
@@ -438,7 +448,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9ee75ffb",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cat_sim_adv[\"ScenarioMIP_NCC_NorESM2-MM_ssp585_r1i1p1f1_gn\"].derivedcat"

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -272,7 +272,10 @@ class DataCatalog(intake_esm.esm_datastore):
     def search(self, **columns):
         """Modification of .search() to add the 'periods' keyword."""
         periods = columns.pop("periods", False)
-        cat = super().search(**columns)
+        if len(columns) > 0:
+            cat = super().search(**columns)
+        else:
+            cat = self.__class__({"esmcat": self.esmcat.dict(), "df": self.esmcat._df})
         if periods is not False:
             cat.esmcat._df = subset_file_coverage(
                 cat.esmcat._df, periods=periods, coverage=0, duplicates_ok=True

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -18,6 +18,7 @@ import dask
 import fsspec as fs
 import intake_esm
 import netCDF4
+import numpy as np
 import pandas as pd
 import tlz
 import xarray
@@ -267,6 +268,16 @@ class DataCatalog(intake_esm.esm_datastore):
             sim = self.search(**dict(zip(columns, values)))
             if sim:  # So we never yield empty catalogs
                 yield values, sim
+
+    def search(self, **columns):
+        """Modification of .search() to add the 'periods' keyword."""
+        periods = columns.pop("periods", False)
+        cat = super().search(**columns)
+        if periods is not False:
+            cat.esmcat._df = subset_file_coverage(
+                cat.esmcat._df, periods=periods, coverage=0, duplicates_ok=True
+            )
+        return cat
 
     def drop_duplicates(self, columns: Optional[List[str]] = None):  # noqa: D102
         # In case variables are being added in an existing Zarr, append them
@@ -1537,3 +1548,106 @@ def unstack_id(
         out[ids] = {attr: subset[attr].iloc[0] for attr in subset.columns}
 
     return out
+
+
+def subset_file_coverage(
+    df: pd.DataFrame,
+    periods: list,
+    *,
+    coverage: float = 0.99,
+    duplicates_ok: bool = False,
+) -> pd.DataFrame:
+    """Return a subset of files that overlap with the target period(s).
+
+    The minimum resolution for periods is 1 hour.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+      List of files to be evaluated, with at least a date_start and date_end column,
+      which are expected to be `pd.Period` objects with `freq='H'`.
+    periods : list
+      [start, end] of the period to be evaluated (or a list of lists)
+    coverage : float
+      Percentage of hours that need to be covered in a given period for the dataset to be valid. Use 0 to ignore this checkup.
+    duplicates_ok: bool
+      If True, no checkup is done on possible duplicates.
+
+    Returns
+    -------
+    pd.DataFrame
+      Subset of files that overlap the targetted period(s)
+    """
+    if not isinstance(periods[0], list):
+        periods = [periods]
+
+    # Create an Interval for each file
+    file_intervals = df.apply(
+        lambda r: pd.Interval(
+            left=r["date_start"].ordinal, right=r["date_end"].ordinal, closed="both"
+        ),
+        axis=1,
+    )
+
+    # Check for duplicated Intervals
+    if any(file_intervals.duplicated()) and duplicates_ok is False:
+        logging.warning(
+            f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Time periods are overlapping."
+        )
+        return pd.DataFrame(columns=df.columns)
+
+    # Create an array of True/False
+    files_to_keep = np.zeros(len(file_intervals), dtype=bool)
+    for period in periods:
+        period_interval = pd.Interval(
+            left=date_parser(str(period[0]), freq="H").ordinal,
+            right=date_parser(str(period[1]), end_of_period=True, freq="H").ordinal,
+            closed="both",
+        )
+        files_in_range = file_intervals.apply(lambda r: period_interval.overlaps(r))
+
+        if len(df[files_in_range]) == 0:
+            logging.warning(
+                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage (no files in range)."
+            )
+            return pd.DataFrame(columns=df.columns)
+
+        # Very rough guess of the coverage relative to the requested period,
+        # without having to open the files or checking day-by-day
+        if coverage > 0:
+            # Number of hours in the requested period
+            period_nb_hrs = date_parser(
+                str(period[1]), end_of_period=True, freq="H"
+            ) - date_parser(str(period[0]), freq="H")
+
+            # Sum of hours in all selected files, restricted by the requested period
+            guessed_nb_hrs_sum = (
+                df[files_in_range].apply(
+                    lambda x: np.min(
+                        [
+                            x["date_end"],
+                            date_parser(str(period[1]), end_of_period=True, freq="H"),
+                        ]
+                    ),
+                    axis=1,
+                )
+                - df[files_in_range].apply(
+                    lambda x: np.max(
+                        [x["date_start"], date_parser(str(period[0]), freq="H")]
+                    ),
+                    axis=1,
+                )
+            ).sum()
+
+            if guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos < coverage:
+                logging.warning(
+                    f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage "
+                    f"(guessed at {guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos:.1%})."
+                )
+                return pd.DataFrame(columns=df.columns)
+
+            files_to_keep = files_to_keep | files_in_range
+        else:
+            files_to_keep = files_to_keep | files_in_range
+
+    return df[files_to_keep]

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -167,7 +167,7 @@ def extract_dataset(
     catalog : DataCatalog
         Sub-catalog for a single dataset, one value of the output of `search_data_catalogs`.
     variables_and_freqs : dict
-        Variables and freqs, following a 'variable: xrfreq-compatible str' format.
+        Variables and freqs, following a 'variable: xrfreq-compatible str' format. A list of strings can also be provided.
         If None, it will be read from catalog._requested_variables and catalog._requested_variable_freqs
         (set by `variables_and_freqs` in `search_data_catalogs`)
     periods : list
@@ -535,7 +535,7 @@ def search_data_catalogs(
     data_catalogs : Union[Union[str, os.PathLike], List[Union[str, os.PathLike]], DataCatalog]
         DataCatalog (or multiple, in a list) or paths to JSON/CSV data catalogs. They must use the same columns and aggregation options.
     variables_and_freqs : dict
-        Variables and freqs to search for, following a 'variable: xr-freq-compatible-str' format.
+        Variables and freqs to search for, following a 'variable: xr-freq-compatible-str' format. A list of strings can also be provided.
     other_search_criteria : dict, optional
         Other criteria to search for in the catalogs' columns, following a 'column_name: list(subset)' format.
     exclusions : dict, optional

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -298,7 +298,12 @@ def extract_dataset(
                 # TODO: 2nd part is a temporary fix until this is changed in intake_esm
                 if (
                     var_name in ds
-                    or xrfreq not in [variables_and_freqs.get(var_name)]
+                    or xrfreq
+                    not in (
+                        variables_and_freqs.get(var_name)
+                        if isinstance(variables_and_freqs.get(var_name), list)
+                        else [variables_and_freqs.get(var_name)]
+                    )
                     or var_name not in catalog._requested_variables_true
                 ):
                     continue

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -260,7 +260,13 @@ def extract_dataset(
     )
 
     out_dict = {}
-    for xrfreq in pd.unique([x for y in list(variables_and_freqs.values()) for x in y]):
+    for xrfreq in pd.unique(
+        [
+            x if isinstance(y, list) else y
+            for y in variables_and_freqs.values()
+            for x in y
+        ]
+    ):
         ds = xr.Dataset()
         attrs = {}
         # iterate on the datasets, in reverse timedelta order

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -421,6 +421,13 @@ def resample(
     """
     var_name = da.name
 
+    initial_frequency = xr.infer_freq(da.time.dt.round("T")) or "undetected"
+    if initial_frequency == "D":
+        logger.warning(
+            "You appear to be resampling daily data using extract_dataset. "
+            "It is advised to use compute_indicators instead, as it is far more robust."
+        )
+
     if method is None:
         if (
             target_frequency in CV.resampling_methods.dict
@@ -492,8 +499,6 @@ def resample(
         out = getattr(da.resample(time=target_frequency), method)(
             dim="time", keep_attrs=True
         )
-
-    initial_frequency = xr.infer_freq(da.time.dt.round("T")) or "undetected"
 
     new_history = (
         f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {method} "

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -298,7 +298,7 @@ def extract_dataset(
                 # TODO: 2nd part is a temporary fix until this is changed in intake_esm
                 if (
                     var_name in ds
-                    or xrfreq not in list(variables_and_freqs.get(var_name))
+                    or xrfreq not in [variables_and_freqs.get(var_name)]
                     or var_name not in catalog._requested_variables_true
                 ):
                     continue

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -422,10 +422,18 @@ def resample(
     var_name = da.name
 
     initial_frequency = xr.infer_freq(da.time.dt.round("T")) or "undetected"
-    if initial_frequency == "D":
+    initial_frequency_td = pd.Timedelta(
+        CV.xrfreq_to_timedelta(xr.infer_freq(da.time.dt.round("T")), None)
+    )
+    if initial_frequency_td == pd.Timedelta("1D"):
         logger.warning(
             "You appear to be resampling daily data using extract_dataset. "
             "It is advised to use compute_indicators instead, as it is far more robust."
+        )
+    elif initial_frequency_td > pd.Timedelta("1D"):
+        logger.warning(
+            "You appear to be resampling data that is coarser than daily. "
+            "Be aware that this is not currently explicitely supported by xscen and might result in erroneous manipulations."
         )
 
     if method is None:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #168
    - This PR fixes #123
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* `DataCatalog.search()` is now managed by us. Added the possibility to search for `periods`.
   * `pcat.search(source="ERA5-Land", periods=[["1990", "2020"]])`
* Modified `subset_file_coverage` to allow skipping the chekups on duplicates and coverage (to support the aforementioned change)
* `search_data_catalogs` and `extract_dataset` now support wanting a variable at different frequencies. This is accomplished using lists. The old behaviour is kept as is, so this is not a breaking change.
    * `variables_and_freqs={"pr": ["H", "D"], "tas": "D"}`
* Fixed a bug in `extract_dataset` where the `sorted` at line 269 was completely broken since it was applied on `CV.xrfreq_to_timedelta` instead of `pd.Timedelta(CV.xrfreq_to_timedelta)`
* Line 274: `extract_dataset` now skips a simulation way earlier if the time resolution is too coarse.

### Does this PR introduce a breaking change?

* Moved `_subset_file_coverage` from `extract.py` to `catalog.py` to prevent circular imports. Also renamed it `subset_file_coverage` (without the underscore). This should not really impact anyone, since it was a hidden function.

### Other information:
