### PR TITLE
Create bounds for RotatedPole, Creep fill

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,8 +15,9 @@ New features and enhancements
 * New 'cos-lat' averaging in ``spatial_mean`` (:issue:`94`, :pull:`125`).
 * Support for computing anomalies in ``compute_deltas``  (:pull:`165`).
 * Add function ``diagnostics.measures_improvement_2d``. (:pull:`167`).
-* Add function ``regrid.create_bounds_rotated_pole`` and automatic use in ``regrid_dataset`` and ``spatial_mean``. This is temporary, while we wait for a functionning method in ``cf_xarray``.
-* Add ``spatial`` submodule with functions ``creep_weights`` and ``creep_fill`` for filling NaNs using neighbours.
+* Add function ``regrid.create_bounds_rotated_pole`` and automatic use in ``regrid_dataset`` and ``spatial_mean``. This is temporary, while we wait for a functionning method in ``cf_xarray``. (:pull:`174`, :issue:`96`).
+* Add ``spatial`` submodule with functions ``creep_weights`` and ``creep_fill`` for filling NaNs using neighbours. (:pull:`174`).
+* Allow passing ``GeoDataFrame`` instances in ``spatial_mean``'s ``region`` argument, not only geospatial file paths. (:pull:`174`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,9 +12,11 @@ Announcements
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* New 'cos-lat' averaging in `spatial_mean` (:issue:`94`, :pull:`125`).
-* Support for computing anomalies in `compute_deltas`  (:pull:`165`).
-* Add function `diagnostics.measures_improvement_2d`. (:pull:`167`).
+* New 'cos-lat' averaging in ``spatial_mean`` (:issue:`94`, :pull:`125`).
+* Support for computing anomalies in ``compute_deltas``  (:pull:`165`).
+* Add function ``diagnostics.measures_improvement_2d``. (:pull:`167`).
+* Add function ``regrid.create_bounds_rotated_pole`` and automatic use in ``regrid_dataset`` and ``spatial_mean``. This is temporary, while we wait for a functionning method in ``cf_xarray``.
+* Add ``spatial`` submodule with functions ``creep_weights`` and ``creep_fill`` for filling NaNs using neighbours.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,6 +71,13 @@ Input / Output
    :members:
    :noindex:
 
+Spatial tools
+-------------
+
+.. automodule:: xscen.spatial
+   :members:
+   :noindex:
+
 Controlled Vocabulary and Mappings
 ----------------------------------
 

--- a/xscen/__init__.py
+++ b/xscen/__init__.py
@@ -15,6 +15,7 @@ from . import (
     reduce,
     regrid,
     scripting,
+    spatial,
     utils,
 )
 

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -450,7 +450,10 @@ def spatial_mean(
                 }
 
             elif region["method"] == "shape":
-                s = gpd.read_file(region["shape"]["shape"])
+                if not isinstance(region["shape"]["shape"], gpd.GeoDataFrame):
+                    s = gpd.read_file(region["shape"]["shape"])
+                else:
+                    s = region["shape"]["shape"]
                 if len(s != 1):
                     raise ValueError(
                         "Only a single polygon should be used with interp_centroid."
@@ -499,7 +502,10 @@ def spatial_mean(
 
         # If the region is a shapefile, open with geopandas
         elif region["method"] == "shape":
-            polygon = gpd.read_file(region["shape"]["shape"])
+            if not isinstance(region["shape"]["shape"], gpd.GeoDataFrame):
+                polygon = gpd.read_file(region["shape"]["shape"])
+            else:
+                polygon = region["shape"]["shape"]
 
             # Simplify the geometries to a given tolerance, if needed.
             # The simpler the polygons, the faster the averaging, but it will lose some precision.

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -519,6 +519,16 @@ def spatial_mean(
 
         kwargs_copy = deepcopy(kwargs)
         skipna = kwargs_copy.pop("skipna", False)
+
+        if (
+            ds.cf["longitude"].ndim == 2
+            and "longitude" not in ds.cf.bounds
+            and "rotated_pole" in ds
+        ):
+            from .regrid import create_bounds_rotated_pole
+
+            ds = ds.update(create_bounds_rotated_pole(ds))
+
         savg = xe.SpatialAverager(ds, polygon.geometry, **kwargs_copy)
         ds_agg = savg(ds, keep_attrs=True, skipna=skipna)
         extra_coords = {

--- a/xscen/spatial.py
+++ b/xscen/spatial.py
@@ -1,0 +1,105 @@
+"""Spatial tools."""
+import itertools
+
+import numpy as np
+import sparse as sp
+import xarray as xr
+
+
+def creep_weights(mask, n=1, mode="clip"):
+    """Compute weights for the creep fill.
+
+    The output is a sparse matrix with the same dimensions as `mask`, twice.
+
+    Parameters
+    ----------
+    mask : DataArray
+      A boolean DataArray. False values are candidates to the filling.
+      Usually they represent missing values (`mask = da.notnull()`).
+      All dimensions are creep filled.
+    n : int
+      The order of neighbouring to use. 1 means only the adjacent grid cells are used.
+    mode : {'clip', 'wrap'}
+      If a cell is on the edge of the domain, `mode='wrap'` will wrap around to find neighbours.
+
+    Returns
+    -------
+    DataArray
+       Weights. The dot product must be taken over the last N dimensions.
+    """
+    da = mask
+    mask = da.values
+    neighbors = np.array(
+        list(itertools.product(*[np.arange(-n, n + 1) for j in range(mask.ndim)]))
+    ).T
+    src = []
+    dst = []
+    w = []
+    it = np.nditer(mask, flags=["f_index", "multi_index"], order="C")
+    for i in it:
+        if not i:
+            neigh_idx_2d = np.atleast_2d(it.multi_index).T + neighbors
+            neigh_idx_1d = np.ravel_multi_index(
+                neigh_idx_2d, mask.shape, order="C", mode=mode
+            )
+            neigh_idx = np.unravel_index(np.unique(neigh_idx_1d), mask.shape, order="C")
+            neigh = mask[neigh_idx]
+            N = (neigh).sum()
+            if N > 0:
+                src.extend([it.multi_index] * N)
+                dst.extend(np.stack(neigh_idx)[:, neigh].T)
+                w.extend([1 / N] * N)
+            else:
+                src.extend([it.multi_index])
+                dst.extend([it.multi_index])
+                w.extend([np.nan])
+        else:
+            src.extend([it.multi_index])
+            dst.extend([it.multi_index])
+            w.extend([1])
+    crds = np.concatenate((np.array(src).T, np.array(dst).T), axis=0)
+    return xr.DataArray(
+        sp.COO(crds, w, (*da.shape, *da.shape)),
+        dims=[f"{d}_out" for d in da.dims] + list(da.dims),
+        coords=da.coords,
+        name="creep_fill_weights",
+    )
+
+
+def creep_fill(da, w):
+    """Creep fill using pre-computed weights.
+
+    Parameters
+    ----------
+    da: DataArray
+      A DataArray sharing the dimensions with the one used to compute the weights.
+      It can have other dimensions.
+      Dask is supported as long as there are no chunks over the creeped dims.
+    w: DataArray
+      The result of `creep_weights`.
+
+    Returns
+    -------
+    xarray.DataArray, same shape as `da`, but values filled according to `w`.
+
+    Examples
+    --------
+    >>> w = creep_weights(da.isel(time=0).notnull(), n=1)
+    >>> da_filled = creep_fill(da, w)
+    """
+
+    def _dot(arr, wei):
+        N = wei.ndim // 2
+        extra_dim = arr.ndim - N
+        return np.tensordot(arr, wei, axes=(np.arange(N) + extra_dim, np.arange(N) + N))
+
+    N = w.ndim // 2
+    return xr.apply_ufunc(
+        _dot,
+        da,
+        w,
+        input_core_dims=[w.dims[N:], w.dims],
+        output_core_dims=[w.dims[N:]],
+        dask="parallelized",
+        output_dtypes=["float64"],
+    )


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR kinda fixes #96
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Add `regrid.create_bounds_rotated_pole`. Uses `cartopy` to get `lon_bounds` and `lat_bounds` from the  Rotated Pole grid mapping. Unique to that projection, but this covers most cases at Ouranos at least... Still waiting for a proper cf-xarray - cartopy link to implement this upstream. Or to have a brilliant idea and fix the estimation in cf-xarray. In the mean time, this is good enough I think. 
    * I added checks in `regrid._regrid` and `spatial_mean` so that the conservative-rotated_pole-no_bounds case is covered automatically.

* Add `xs.spatial` for spatial tools. Currently only the `creep_fill` method to fill missing values with the mean of the neighbours. Can also be used for other purposes like making wider land-sea masks.
 
* Allow passing `GeoDataFrame` in `spatial_mean`'s `region`. This is useful if you want to open a shapefile and subset it before the mean.

### Does this PR introduce a breaking change?
No.

### Other information:
