### PR TITLE
fix 156

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,7 @@ Bug fixes
 * Forbid pandas v1.5.3 in the environment files, as the linux conda build breaks the data catalog parser. (:issue:`161`, :pull:`162`).
 * Only return requested variables when using ``DataCatalog.to_dataset`` (:pull:`163`).
 * `compute_indicators` no longer crashes if less than 3 timesteps are produced (:pull:`125`).
+* `xscen.utils.unstack_fill_nan`` can now handle datasets that have non dimension coordinates. (:issue:`156`, :pull:`175`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #156 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Previously if the dataset had coordinates that were not dimensions (like lat and lon on a rotated grid where the dimensions are rlat and rlon), the unstacking would fail when used with a file. Now, the function distinguished between dimension and other coords. It unstacks and reindexs only on the dimensions and then adds the other coords.
* The function is now completely separating treating the case with file and without file. I know this brings a bit of redundancy but I wasn't sure how else to do it.

### Does this PR introduce a breaking change?
The normal case with only lat and lon still works.

### Other information:
