### PR TITLE
fix extract for variable not in variables_and_freqs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,7 @@ Breaking changes
 * 'interp_coord' has been renamed to 'interp_centroid' in `spatial_mean`. (:pull:`125`).
 * The 'datasets' dimension of the output of ``diagnostics.measures_heatmap`` is renamed 'realization'. (:pull:`167`).
 * `_subset_file_coverage` was renamed `subset_file_coverage` and moved to ``catalog.py`` to prevent circular imports. (:pull:`170`).
+* `extract_dataset` doesn't fail when a variable is in the dataset, but not `variables_and_freqs`. (:pull:`185`).
 
 Bug fixes
 ^^^^^^^^^

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -242,7 +242,7 @@ def extract_dataset(
                 # TODO: 2nd part is a temporary fix until this is changed in intake_esm
                 if (
                     var_name in ds
-                    or xrfreq not in variables_and_freqs.get(var_name)
+                    or xrfreq not in variables_and_freqs.get(var_name, [])
                     or var_name not in catalog._requested_variables_true
                 ):
                     continue


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Context: I bias adjust 3 variables separately (tasmax, dtr and pr) and I want to reassemble them as (tasmax, tasmin and pr) using extract_dataset.
* This used to work well, but I think commit 6606a41 broke it. Before this PR, line 245 would fail (`TypeError: argument of type 'NoneType' is not iterable`).
 `variables_and_freqs.get('dtr)` would return None and `xrfreq not in None` fails. 
* With my change, `variables_and_freqs.get('dtr)` returns an empty list instead and doesn't fail.

### Does this PR introduce a breaking change?
no

### Other information:
