### PR TITLE
fix incorrect time reconstruction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,7 +42,7 @@ Bug fixes
 * `xscen.utils.unstack_fill_nan`` can now handle datasets that have non dimension coordinates. (:issue:`156`, :pull:`175`).
 * `extract_dataset` now skips a simulation way earlier if the frequency doesn't match. (:pull:`170`).
 * `extract_dataset` now correctly tries to extract in reverse timedelta order. (:pull:`170`).
-
+* `compute_deltas` no longer creates all NaN values if the input dataset is in a non-standard calendar. (:pull:`188`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -124,12 +124,14 @@ def climatological_mean(
         ds_rolling = ds_rolling.stack(time=("year", "month", "day"))
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
-            time_coord = pd.to_datetime(
-                {
-                    "year": ds_rolling.year.values - window + 1,
-                    "month": ds_rolling.month.values,
-                    "day": ds_rolling.day.values,
-                }
+            time_coord = list(
+                pd.to_datetime(
+                    {
+                        "year": ds_rolling.year.values - window + 1,
+                        "month": ds_rolling.month.values,
+                        "day": ds_rolling.day.values,
+                    }
+                ).values
             )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [
@@ -291,12 +293,14 @@ def compute_deltas(
         deltas = deltas.stack(time=("year", "month", "day"))
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
-            time_coord = pd.to_datetime(
-                {
-                    "year": deltas.year.values,
-                    "month": deltas.month.values,
-                    "day": deltas.day.values,
-                }
+            time_coord = list(
+                pd.to_datetime(
+                    {
+                        "year": deltas.year.values,
+                        "month": deltas.month.values,
+                        "day": deltas.day.values,
+                    }
+                ).values
             )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -7,6 +7,7 @@ from pathlib import Path, PosixPath
 from types import ModuleType
 from typing import Sequence, Tuple, Union
 
+import cftime
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -122,12 +123,26 @@ def climatological_mean(
         # get back to 1D time
         ds_rolling = ds_rolling.stack(time=("year", "month", "day"))
         # rebuild time coord
-        time_coord = [
-            pd.to_datetime(f"{y - window + 1}, {m}, {d}")
-            for y, m, d in zip(
-                ds_rolling.year.values, ds_rolling.month.values, ds_rolling.day.values
-            )
-        ]
+        if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
+            time_coord = [
+                pd.to_datetime(f"{y}, {m}, {d}")
+                for y, m, d in zip(
+                    ds_rolling.year.values,
+                    ds_rolling.month.values,
+                    ds_rolling.day.values,
+                )
+            ]
+        elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
+            time_coord = [
+                cftime.datetime(y, m, d, calendar=ds.indexes["time"].calendar)
+                for y, m, d in zip(
+                    ds_rolling.year.values,
+                    ds_rolling.month.values,
+                    ds_rolling.day.values,
+                )
+            ]
+        else:
+            raise ValueError("The type of 'time' could not be understood.")
         ds_rolling = ds_rolling.assign_coords(time=time_coord).transpose("time", ...)
 
         concats.extend([ds_rolling])
@@ -274,12 +289,23 @@ def compute_deltas(
         # get back to 1D time
         deltas = deltas.stack(time=("year", "month", "day"))
         # rebuild time coord
-        time_coord = [
-            pd.to_datetime(f"{y}, {m}, {d}")
-            for y, m, d in zip(
-                deltas.year.values, deltas.month.values, deltas.day.values
-            )
-        ]
+        if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
+            time_coord = [
+                pd.to_datetime(f"{y}, {m}, {d}")
+                for y, m, d in zip(
+                    deltas.year.values, deltas.month.values, deltas.day.values
+                )
+            ]
+        elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
+            time_coord = [
+                cftime.datetime(y, m, d, calendar=ds.indexes["time"].calendar)
+                for y, m, d in zip(
+                    deltas.year.values, deltas.month.values, deltas.day.values
+                )
+            ]
+        else:
+            raise ValueError("The type of 'time' could not be understood.")
+
         deltas = deltas.assign(time=time_coord).transpose("time", ...)
         deltas = deltas.reindex_like(ds)
 

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -292,12 +292,9 @@ def compute_deltas(
         deltas = deltas.stack(time=("year", "month", "day"))
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
-            time_coord = [
-                pd.to_datetime(f"{y}, {m}, {d}")
-                for y, m, d in zip(
-                    deltas.year.values, deltas.month.values, deltas.day.values
-                )
-            ]
+            time_coord = pd.to_datetime(
+                {'year': deltas.year.values, 'month': deltas.month.values, 'day': deltas.day.values}
+            )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [
                 cftime.datetime(y, m, d, calendar=ds.indexes["time"].calendar)

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -125,7 +125,7 @@ def climatological_mean(
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
             time_coord = [
-                pd.to_datetime(f"{y}, {m}, {d}")
+                pd.to_datetime(f"{y - window + 1}, {m}, {d}")
                 for y, m, d in zip(
                     ds_rolling.year.values,
                     ds_rolling.month.values,
@@ -134,7 +134,9 @@ def climatological_mean(
             ]
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [
-                cftime.datetime(y, m, d, calendar=ds.indexes["time"].calendar)
+                cftime.datetime(
+                    y - window + 1, m, d, calendar=ds.indexes["time"].calendar
+                )
                 for y, m, d in zip(
                     ds_rolling.year.values,
                     ds_rolling.month.values,

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -125,7 +125,11 @@ def climatological_mean(
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
             time_coord = pd.to_datetime(
-                {"year": ds_rolling.year.values - window + 1, "month": ds_rolling.month.values, "day": ds_rolling.day.values}
+                {
+                    "year": ds_rolling.year.values - window + 1,
+                    "month": ds_rolling.month.values,
+                    "day": ds_rolling.day.values,
+                }
             )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [
@@ -288,7 +292,11 @@ def compute_deltas(
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
             time_coord = pd.to_datetime(
-                {'year': deltas.year.values, 'month': deltas.month.values, 'day': deltas.day.values}
+                {
+                    "year": deltas.year.values,
+                    "month": deltas.month.values,
+                    "day": deltas.day.values,
+                }
             )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -124,14 +124,9 @@ def climatological_mean(
         ds_rolling = ds_rolling.stack(time=("year", "month", "day"))
         # rebuild time coord
         if isinstance(ds.indexes["time"], pd.core.indexes.datetimes.DatetimeIndex):
-            time_coord = [
-                pd.to_datetime(f"{y - window + 1}, {m}, {d}")
-                for y, m, d in zip(
-                    ds_rolling.year.values,
-                    ds_rolling.month.values,
-                    ds_rolling.day.values,
-                )
-            ]
+            time_coord = pd.to_datetime(
+                {"year": ds_rolling.year.values - window + 1, "month": ds_rolling.month.values, "day": ds_rolling.day.values}
+            )
         elif isinstance(ds.indexes["time"], xr.coding.cftimeindex.CFTimeIndex):
             time_coord = [
                 cftime.datetime(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Bugfix, especially for `compute_deltas`. The line `deltas = deltas.reindex_like(ds)` would create all NaN values if `ds` was using a `CFTimeIndex` (such as a 'noleap' calendar) instead of a pandas `DatetimeIndex`. The same wasn't true for `climatological_mean` since we don't reindex, but we might as well use the same indexes as the input dataset.

### Does this PR introduce a breaking change?

- No

### Other information:

