### PR TITLE
unstack horizon

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,7 +20,7 @@ Breaking changes
 
 Bug fixes
 ^^^^^^^^^
-* N/A
+* Fix bug in ``unstack_dates`` with seasonal climatological mean. (:issue:`202`, :pull:`202`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -87,6 +87,7 @@ def climatological_mean(
         names=["year", "month", "day"],
     )
     ds_unstack = ds.assign(time=ind).unstack("time")
+
     # Rolling will ignore jumps in time, so we want to raise an exception beforehand
     if (not all(ds_unstack.year.diff(dim="year", n=1) == 1)) & (periods is None):
         raise ValueError("Data is not continuous. Use the 'periods' argument.")
@@ -151,6 +152,7 @@ def climatological_mean(
             raise ValueError("The type of 'time' could not be understood.")
         ds_rolling = ds_rolling.drop_vars({"month", "year", "time", "day"})
         ds_rolling = ds_rolling.assign_coords(time=time_coord).transpose("time", ...)
+
         concats.extend([ds_rolling])
     ds_rolling = xr.concat(concats, dim="time", data_vars="minimal")
 

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -87,7 +87,6 @@ def climatological_mean(
         names=["year", "month", "day"],
     )
     ds_unstack = ds.assign(time=ind).unstack("time")
-
     # Rolling will ignore jumps in time, so we want to raise an exception beforehand
     if (not all(ds_unstack.year.diff(dim="year", n=1) == 1)) & (periods is None):
         raise ValueError("Data is not continuous. Use the 'periods' argument.")
@@ -150,8 +149,8 @@ def climatological_mean(
             ]
         else:
             raise ValueError("The type of 'time' could not be understood.")
+        ds_rolling = ds_rolling.drop_vars({"month", "year", "time", "day"})
         ds_rolling = ds_rolling.assign_coords(time=time_coord).transpose("time", ...)
-
         concats.extend([ds_rolling])
     ds_rolling = xr.concat(concats, dim="time", data_vars="minimal")
 
@@ -680,7 +679,7 @@ def produce_horizon(
         )
     if period is not None:
         period = standardize_periods(period, multiple=False)
-        ds = ds.sel(time=slice(period[0], period[1]))  # .load()
+        ds = ds.sel(time=slice(period[0], period[1]))
         window = int(period[1]) - int(period[0]) + 1
         if to_level:
             to_level = to_level.format(period0=period[0], period1=period[1])

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -680,7 +680,7 @@ def produce_horizon(
         )
     if period is not None:
         period = standardize_periods(period, multiple=False)
-        ds = ds.sel(time=slice(period[0], period[1])).load()
+        ds = ds.sel(time=slice(period[0], period[1]))  # .load()
         window = int(period[1]) - int(period[0]) + 1
         if to_level:
             to_level = to_level.format(period0=period[0], period1=period[1])

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -889,6 +889,15 @@ def unstack_dates(
             da = flox.xarray.rechunk_for_blockwise(da, "time", years)
         return xr.DataArray(da.data.reshape(new_shape), dims=new_dims)
 
+    new_coords = dict(ds.coords)
+    new_coords.update({"time": new_time, new_dim: seas_list})
+
+    # put horizon in the right time dimension
+    if "horizon" in new_coords:
+        new_coords["horizon"] = (
+            reshape_da(new_coords["horizon"]).isel({new_dim: 0}).squeeze()
+        )
+
     if isinstance(ds, xr.Dataset):
         dso = dsp.map(reshape_da, keep_attrs=True)
     else:

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -892,9 +892,7 @@ def unstack_dates(
 
     # put horizon in the right time dimension
     if "horizon" in new_coords:
-        new_coords["horizon"] = (
-            reshape_da(new_coords["horizon"]).isel({new_dim: 0}).squeeze()
-        )
+        new_coords["horizon"] = reshape_da(new_coords["horizon"])
 
     if isinstance(ds, xr.Dataset):
         dso = dsp.map(reshape_da, keep_attrs=True)

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -868,8 +868,6 @@ def unstack_dates(
         calendar=calendar,
         use_cftime=use_cftime,
     )
-    new_coords = dict(ds.coords)
-    new_coords.update({"time": new_time, new_dim: seas_list})
 
     def reshape_da(da):
         if "time" not in da.dims:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #202 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*  `new_coords['horizon']` was still the length of the original time dimension. I guess before xarray was able to make it fit with the new `time` dimension, but it doesn't seem to work anymore. I manually unstack`horizon` similarly to the variables.
* Also dropped coords in `climatological_mean` to address a future warning (`FutureWarning: Updating MultiIndexed coordinate 'time' would corrupt indices for other variables: ['year', 'month', 'day']. This will raise an error in the future. Use `.drop_vars({'month', 'year', 'time', 'day'})` before assigning new coordinate values.
`)

### Does this PR introduce a breaking change?
no

### Other information:
