### PR TITLE
Modify RtD install step to prevent --eager dependency changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,14 +12,11 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
+    post_create_environment:
+      - pip install . --no-deps
     pre_build:
       - sphinx-apidoc -o docs/ --private --module-first xscen
       - env SKIP_NOTEBOOKS=1 sphinx-build -b linkcheck docs/ _build/linkcheck
 
 conda:
   environment: environment-dev.yml
-
-python:
-  install:
-    - method: pip
-      path: .

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Removed the pin on xarray's version. (:issue:`175`, :pull:`199`).
+* Updated ReadTheDocs configuration to prevent ``--eager`` installation of xscen (:pull:`209`).
 
 v0.6.0 (2023-05-04)
 -------------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: xscen-dev
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9
+  - python >=3.9,<3.11
   # Don't forget to sync the changes here with environment.yml!
   # Some pins here are meant to accelerate conda and might not be related to real needs
   # Main packages
@@ -29,10 +29,6 @@ dependencies:
   - xclim >=0.37
   - xesmf >=0.7
   - zarr
-  # To avoid bugs
-  # See https://github.com/esmf-org/esmf/issues/115
-  # we add this "dependency" so the following pip install doesn't install anything else than xscen
-  - pytest-json-report
   # Opt
   - nc-time-axis >=1.3.1
   - pyarrow >=1.0.0  # For lighter in-memory catalogs

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: xscen
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9
+  - python >=3.9,<3.11
   # Don't forget to sync the changes here with environment-dev.yml!
   # Main packages
   - cartopy
@@ -28,10 +28,6 @@ dependencies:
   - xclim >=0.37
   - xesmf >=0.7
   - zarr
-  # To avoid bugs
-  # See https://github.com/esmf-org/esmf/issues/115
-  # we add this "dependency" so the following pip install doesn't install anything else than xscen
-  - pytest-json-report
   # Opt
   - nc-time-axis >=1.3.1
   - pyarrow >=1.0.0


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Changes the way that ReadTheDocs installs `xscen` to prevent it from changing dependencies with `pip`
* Removes `pytest-json-report` from the environment

### Does this PR introduce a breaking change?

No.

### Other information:
