### PR TITLE
Fix build-path for out-of-bounds dates

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,5 +19,5 @@ Contributors
 
 * Travis Logan <logan.travis@ouranos.ca> `@tlogan2000 <https://github.com/tlogan2000>`_
 * Louis-Philippe Caron <caron.louis-philippe@ouranos.ca>
-* Sarah Gammon <gammon.sarah@ouranos.ca> `@sg2475962 <https://github.com/sg2475962>`_
+* Sarah Gammon <gammon.sarah@ouranos.ca> `@SarahG-579462 <https://github.com/SarahG-579462>`_
 * Yannick Rousseau

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -100,7 +100,7 @@ Internal changes
 
 v0.5.0 (2023-02-28)
 -------------------
-Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`), Sarah Gammon (:user:`sg2475962`) and Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`), Sarah Gammon (:user:`SarahG-579462`) and Pascal Bourgault (:user:`aulemahal`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,6 +35,7 @@ Internal changes
 * Updated GitHub Actions to remove deprecation warnings. (:pull:`187`).
 * Updated the cookiecutter used to generate boilerplate documentation and code via `cruft`. (:pull:`212`).
 * A few changes to `subset_warming_level` so it doesn't need `driving_institution`. (:pull:`215`).
+* Injection of a better ``__format__`` method in ``pd.Period``, allowing use of these in f-strings with strftime-like format strings. (:pull:`218`).
 
 v0.6.0 (2023-05-04)
 -------------------

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -231,15 +231,18 @@ def test_build_path(samplecat):
 
 def test_build_path_ds():
     ds = xr.tutorial.open_dataset("air_temperature")
+    ds = ds.assign(time=xr.cftime_range("0001-01-01", freq="6H", periods=ds.time.size))
     ds.attrs.update(source="source", institution="institution")
     new_path = cu.build_path(
         ds,
         schemas={
             "folders": ["source", "institution", ["variable", "xrfreq"]],
-            "filename": ["source", "institution", "variable", "frequency"],
+            "filename": ["source", "institution", "variable", "frequency", "DATES"],
         },
     )
-    assert new_path == Path("source/institution/air_6H/source_institution_air_6hr")
+    assert new_path == Path(
+        "source/institution/air_6H/source_institution_air_6hr_0001-0002"
+    )
 
 
 def test_build_path_multivar(samplecat):

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -101,6 +101,22 @@ esm_col_data = {
 """Default ESM column data for the official catalogs."""
 
 
+# Patch Period.__format__ to act like strftime
+def _patch_period_format():
+    def __format__(self, fmt):
+        # same implementation as datetime.datetime.__format__
+        if not isinstance(fmt, str):
+            raise TypeError("must be str, not %s" % type(fmt).__name__)
+        if len(fmt) != 0:
+            return self.strftime(fmt.replace("%Y", "%4Y"))
+        return str(self)
+
+    pd.Period.__format__ = __format__
+
+
+_patch_period_format()
+
+
 def _parse_list_of_strings(elem):
     """Parse an element of a csv in case it is a tuple of strings."""
     if elem.startswith("(") or elem.startswith("["):

--- a/xscen/catutils.py
+++ b/xscen/catutils.py
@@ -890,8 +890,8 @@ def _schema_dates(facets):
     if facets["xrfreq"] == "fx":
         return "fx"
 
-    start = date_parser(facets["date_start"], out_dtype="datetime")
-    end = date_parser(facets["date_end"], out_dtype="datetime")
+    start = date_parser(facets["date_start"])
+    end = date_parser(facets["date_end"])
     freq = pd.Timedelta(CV.xrfreq_to_timedelta(facets["xrfreq"]))
 
     # Full years : Starts on Jan 1st and is either annual or ends on Dec 31st (accepting Dec 30 for 360 cals)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #217 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fix `build_path` to it uses `Period` objects, allowing dates from outside the `datetime64[ns]` bounds.
* Inject a better `__format__()` in `pd.Period`, so it's easier to use.

### Does this PR introduce a breaking change?
No

### Other information:
I could have avoided the injection by using `datetime64[s]` instead, but this requires pandas 2. Clisops 0.9.6's conda package doesn't have the good dependencies, so we currently can't install pandas 2 in a conda env for xscen. This should be fixed soon with clisops 0.9.7.
