### PR TITLE
Dates as datetime64[ms] - remove `driving_institution`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 #            tox-build: "py39"
           - python-version: "3.10"
 #            tox-build: "py310"
-#          - python-version: "3.11"
+          - python-version: "3.11"
 #            tox-build: "py311"
     defaults:
       run:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Pascal
 
 Announcements
 ^^^^^^^^^^^^^
-* Dropped support for Python 3.8. (:pull:`199`).
+* Dropped support for Python 3.8, added support for 3.11. (:pull:`199`,:pull:`222`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,9 +19,9 @@ New features and enhancements
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* Columns ``date_start`` and ``date_end`` now use a ``datetime64[ms]`` dtype.
-* The default output of ``date_parser`` is now ``pd.Timestamp`` (``output_dtype='datetime'``).
-* ``driving_institution`` was removed from the "default" xscen columns.
+* Columns ``date_start`` and ``date_end`` now use a ``datetime64[ms]`` dtype. (:pull:`222`).
+* The default output of ``date_parser`` is now ``pd.Timestamp`` (``output_dtype='datetime'``). (:pull:`222`).
+* ``driving_institution`` was removed from the "default" xscen columns. (:pull:`222`).
 * Folder parsing utilities (``parse_directory``) moved to ``xscen.catutils``. Signature changed : ``globpattern`` removed, ``dirglob`` added, new ``patterns`` specifications. See doc for all changes. (:pull:`205`).
 
 Bug fixes

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,9 @@ New features and enhancements
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
+* Columns ``date_start`` and ``date_end`` now use a ``datetime64[ms]`` dtype.
+* The default output of ``date_parser`` is now ``pd.Timestamp`` (``output_dtype='datetime'``).
+* ``driving_institution`` was removed from the "default" xscen columns.
 * Folder parsing utilities (``parse_directory``) moved to ``xscen.catutils``. Signature changed : ``globpattern`` removed, ``dirglob`` added, new ``patterns`` specifications. See doc for all changes. (:pull:`205`).
 
 Bug fixes
@@ -35,7 +38,6 @@ Internal changes
 * Updated GitHub Actions to remove deprecation warnings. (:pull:`187`).
 * Updated the cookiecutter used to generate boilerplate documentation and code via `cruft`. (:pull:`212`).
 * A few changes to `subset_warming_level` so it doesn't need `driving_institution`. (:pull:`215`).
-* Injection of a better ``__format__`` method in ``pd.Period``, allowing use of these in f-strings with strftime-like format strings. (:pull:`218`).
 
 v0.6.0 (2023-05-04)
 -------------------

--- a/docs/columns.rst
+++ b/docs/columns.rst
@@ -28,9 +28,6 @@ the four columns will be combined in a single Dataset when any of the first thre
 - ``activity``: Model Intercomparison Project (MIP) associated with the data. This is the same as `activity_id` in CMIP6 data. CMIP is the activity for the historical experiment and the DECK experiments.
     - E.g. "CMIP", "CORDEX", "HighResMIP"
 
-- ``driving_institution``: Institution of the driver model.
-    - E.g. "CCCma"
-
 - ``driving_model``: Name of the driver. Following the `driving_model` convention from ES-DOC, this is in the format "institution-model".
     - E.g. "CCCma-CanESM2"
 
@@ -58,11 +55,11 @@ the four columns will be combined in a single Dataset when any of the first thre
 - ``domain``: Name of the region covered by the dataset. It can also contain information on the grid.
     - E.g. "global", "NAM", "ARC-44",  "ARC-22"
 
-- ``date_start``: First date of the dataset. This a pd.Period object with an hourly frequency.
-    - E.g. "2022-06-03 00:00"
+- ``date_start``: First date of the dataset. This usually is a Datetime object with a ms resolution.
+    - E.g. "2022-06-03 00:00:00"
 
-- ``date_end``: Last date of the dataset. This a pd.Period object with an hourly frequency.
-    - E.g. "2022-06-03 00:00"
+- ``date_end``: Last date of the dataset. This usually is a Datetime object with a ms resolution.
+    - E.g. "2022-06-03 00:00:00"
 
 - ``version``: Version of the dataset.
     - E.g. "1.0"

--- a/docs/notebooks/1_catalog.ipynb
+++ b/docs/notebooks/1_catalog.ipynb
@@ -36,7 +36,6 @@
     "| bias_adjust_project | Name of the project that computed the bias adjustment. |\n",
     "| mip_era | CMIP Generation associated with the data. |\n",
     "| activity | Model Intercomparison Project (MIP) associated with the data. |\n",
-    "| driving_institution | Institution of the driver model. |\n",
     "| driving_model | Name of the driver. |\n",
     "| institution | Institution associated with the source. |\n",
     "| source | Name of the model or the dataset. |\n",
@@ -1023,14 +1022,6 @@
     "PC.df[\"path\"] = newdf[\"new_path\"]\n",
     "PC.update()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f34b3727",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1053,7 +1044,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/2_getting_started.ipynb
+++ b/docs/notebooks/2_getting_started.ipynb
@@ -1270,7 +1270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/3_diagnostics.ipynb
+++ b/docs/notebooks/3_diagnostics.ipynb
@@ -399,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/4_ensemble_reduction.ipynb
+++ b/docs/notebooks/4_ensemble_reduction.ipynb
@@ -171,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/5_warminglevels.ipynb
+++ b/docs/notebooks/5_warminglevels.ipynb
@@ -460,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/6_config.ipynb
+++ b/docs/notebooks/6_config.ipynb
@@ -383,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,14 +2,15 @@ name: xscen-dev
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9,<3.11 # FIXME: CLISOPS is blocking Python3.11
+  - python >=3.9
   # Don't forget to sync the changes here with environment.yml!
-  # Some pins here are meant to accelerate conda and might not be related to real needs
+  # FIXME pins
+  - pydantic < 2  # breaks intake-esm, See: https://github.com/intake/intake-esm/issues/617
   # Main packages
   - cartopy
   - cftime
   - cf_xarray >=0.7.6
-  - clisops >=0.9.5
+  - clisops >=0.10
   - dask
   - flox
   - fsspec
@@ -20,9 +21,8 @@ dependencies:
   - matplotlib
   - netCDF4
   - numpy
-  - pandas !=1.5.3
+  - pandas >= 2
   - parse
-  - pydantic <2.0  # See: https://github.com/intake/intake-esm/issues/617
   - pygeos
   - pyyaml
   - rechunker

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,15 @@ name: xscen
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9,<3.11 # FIXME: CLISOPS is blocking Python3.11
+  - python >=3.9
   # Don't forget to sync the changes here with environment-dev.yml!
+  # FIXME
+  - pydantic <2.0  # See: https://github.com/intake/intake-esm/issues/617
   # Main packages
   - cartopy
   - cftime
   - cf_xarray >=0.7.6
-  - clisops >=0.9.5
+  - clisops >=0.10
   - dask
   - flox
   - fsspec
@@ -19,9 +21,8 @@ dependencies:
   - matplotlib
   - netCDF4
   - numpy
-  - pandas !=1.5.3
+  - pandas >= 2
   - parse
-  - pydantic <2.0  # See: https://github.com/intake/intake-esm/issues/617
   - pygeos
   - pyyaml
   - rechunker

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-
 """The setup script."""
-
-import re
-
 from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:
@@ -25,7 +21,7 @@ requirements = [
     "cartopy",
     "cftime",
     "cf_xarray>=0.7.6",
-    "clisops>=0.9.5",
+    "clisops>=0.10",
     "dask",
     "flox",
     "fsspec",
@@ -36,7 +32,7 @@ requirements = [
     "matplotlib",
     "netCDF4",
     "numpy",
-    "pandas!=1.5.3",
+    "pandas>=2",
     "parse",
     "pyarrow",  # Used when opening catalogs.
     "pydantic<2.0",  # See: https://github.com/intake/intake-esm/issues/617
@@ -45,7 +41,7 @@ requirements = [
     "rechunker",
     "shapely",
     "xarray",
-    "xclim>=0.37",
+    "xclim>=0.43",
     "xesmf>=0.7",
     "zarr",
 ]
@@ -63,7 +59,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        # "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
     ],
     description="A climate change scenario-building analysis framework, built with xclim/xarray.",

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -122,10 +122,10 @@ def test_parse_directory():
     assert (
         df[df["experiment"] != "ssp126"]["driving_model"].isnull().all()
     )  # CVS complex
-    assert df.date_start.dtype == "period[H]"
-    assert df.date_end.dtype == "period[H]"
+    assert df.date_start.dtype == "<M8[ms]"
+    assert df.date_end.dtype == "<M8[ms]"
     assert (
-        df[df["frequency"] == "day"]["date_end"] == pd.Period("2050-12-31", "H")
+        df[df["frequency"] == "day"]["date_end"] == pd.Timestamp("2050-12-31")
     ).all()  # Read from file
     # Read from file + attrs cvs
     assert set(
@@ -150,7 +150,7 @@ def test_parse_directory_readgroups():
     )
     assert len(df) == 10
     t2m = df.variable.apply(lambda v: "t2m" in v)
-    assert (df[t2m]["date_end"] == pd.Period("2050-12-31", "H")).all()
+    assert (df[t2m]["date_end"] == pd.Timestamp("2050-12-31")).all()
     assert (df[~t2m].variable.apply(len) == 0).all()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+import cftime
+import numpy as np
+import pandas as pd
+import pytest
+
+import xscen as xs
+
+
+class TestDateParser:
+    @pytest.mark.parametrize(
+        "date,end_of_period,dtype,exp",
+        [
+            ("2001", True, "datetime", pd.Timestamp("2001-12-31")),
+            ("150004", True, "datetime", pd.Timestamp("1500-04-30")),
+            ("31231212", None, "datetime", pd.Timestamp("3123-12-12")),
+            ("2001-07-08", None, "period", pd.Period("2001-07-08", "H")),
+            (pd.Timestamp("1993-05-20T12:07"), None, "str", "1993-05-20"),
+            (
+                cftime.Datetime360Day(1981, 2, 30),
+                None,
+                "datetime",
+                pd.Timestamp("1981-02-28"),
+            ),
+            (np.datetime64("1200-11-12"), "Y", "datetime", pd.Timestamp("1200-12-31")),
+            (
+                datetime(2045, 5, 2, 13, 45),
+                None,
+                "datetime",
+                pd.Timestamp("2045-05-02T13:45"),
+            ),
+            ("abc", None, "datetime", pd.Timestamp("NaT")),
+            ("", True, "datetime", pd.Timestamp("NaT")),
+        ],
+    )
+    def test_normal(self, date, end_of_period, dtype, exp):
+        out = xs.utils.date_parser(date, end_of_period=end_of_period, out_dtype=dtype)
+        if pd.isna(exp):
+            assert pd.isna(out)
+        else:
+            assert out == exp

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -159,7 +159,7 @@ class DataCatalog(intake_esm.esm_datastore):
         super().__init__(*args, **kwargs)
 
         # Cast date columns into datetime (with ms reso, that's why we do it here and not in the `read_csv_kwargs`)
-        # Pandas >=2,<=2.0.3 support [ms] resolution, but can't parse strings with this resolution, so we need to go through numpy
+        # Pandas >=2 supports [ms] resolution, but can't parse strings with this resolution, so we need to go through numpy
         for datecol in ["date_start", "date_end"]:
             if datecol in self.df.columns and self.df[datecol].dtype == "O":
                 # Missing values in object columns are np.nan, which numpy can't convert to datetime64 (what's up with that numpy???)

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -8,6 +8,8 @@ import re
 import warnings
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from functools import reduce
+from operator import or_
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -49,7 +51,6 @@ COLUMNS = [
     "bias_adjust_project",
     "mip_era",
     "activity",
-    "driving_institution",
     "driving_model",
     "institution",
     "source",
@@ -101,22 +102,6 @@ esm_col_data = {
 """Default ESM column data for the official catalogs."""
 
 
-# Patch Period.__format__ to act like strftime
-def _patch_period_format():
-    def __format__(self, fmt):
-        # same implementation as datetime.datetime.__format__
-        if not isinstance(fmt, str):
-            raise TypeError("must be str, not %s" % type(fmt).__name__)
-        if len(fmt) != 0:
-            return self.strftime(fmt.replace("%Y", "%4Y"))
-        return str(self)
-
-    pd.Period.__format__ = __format__
-
-
-_patch_period_format()
-
-
 def _parse_list_of_strings(elem):
     """Parse an element of a csv in case it is a tuple of strings."""
     if elem.startswith("(") or elem.startswith("["):
@@ -146,8 +131,6 @@ csv_kwargs = {
     "converters": {
         "variable": _parse_list_of_strings,
     },
-    "parse_dates": ["date_start", "date_end"],
-    "date_parser": _parse_dates,
 }
 """Kwargs to pass to `pd.read_csv` when opening an official Ouranos catalog."""
 
@@ -174,6 +157,16 @@ class DataCatalog(intake_esm.esm_datastore):
         args = args_as_str(args)
 
         super().__init__(*args, **kwargs)
+
+        # Cast date columns into datetime (with ms reso, that's why we do it here and not in the `read_csv_kwargs`)
+        # Pandas >=2,<=2.0.3 support [ms] resolution, but can't parse strings with this resolution, so we need to go through numpy
+        for datecol in ["date_start", "date_end"]:
+            if datecol in self.df.columns and self.df[datecol].dtype == "O":
+                # Missing values in object columns are np.nan, which numpy can't convert to datetime64 (what's up with that numpy???)
+                self.df[datecol] = (
+                    self.df[datecol].fillna("").to_numpy().astype("datetime64[ms]")
+                )
+
         if check_valid:
             self.check_valid()
         if drop_duplicates:
@@ -905,17 +898,17 @@ def subset_file_coverage(
 ) -> pd.DataFrame:
     """Return a subset of files that overlap with the target periods.
 
-    The minimum resolution for periods is 1 hour.
-
     Parameters
     ----------
     df : pd.DataFrame
       List of files to be evaluated, with at least a date_start and date_end column,
-      which are expected to be `pd.Period` objects with `freq='H'`.
+      which are expected to be `datetime64` objecs.
     periods : list
       Either [start, end] or list of [start, end] for the periods to be evaluated.
+      All periods must be covered, otherwise an empty subset is returned.
     coverage : float
       Percentage of hours that need to be covered in a given period for the dataset to be valid. Use 0 to ignore this checkup.
+      The coverage calculation is only valid if there are no overlapping periods in `df` (ensure with `duplicates_ok=False`).
     duplicates_ok: bool
       If True, no checkup is done on possible duplicates.
 
@@ -927,33 +920,30 @@ def subset_file_coverage(
     periods = standardize_periods(periods)
 
     # Create an Interval for each file
-    file_intervals = df.apply(
-        lambda r: pd.Interval(
-            left=r["date_start"].ordinal, right=r["date_end"].ordinal, closed="both"
-        ),
-        axis=1,
+    intervals = pd.IntervalIndex.from_arrays(
+        df["date_start"], df["date_end"], closed="both"
     )
 
     # Check for duplicated Intervals
-    if any(file_intervals.duplicated()) and duplicates_ok is False:
+    if duplicates_ok is False and intervals.is_overlapping:
         logging.warning(
             f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Time periods are overlapping."
         )
         return pd.DataFrame(columns=df.columns)
 
     # Create an array of True/False
-    files_to_keep = np.zeros(len(file_intervals), dtype=bool)
+    files_to_keep = []
     for period in periods:
         period_interval = pd.Interval(
-            left=date_parser(period[0], freq="H").ordinal,
-            right=date_parser(period[1], end_of_period=True, freq="H").ordinal,
+            date_parser(period[0]),
+            date_parser(period[1], end_of_period=True),
             closed="both",
         )
-        files_in_range = file_intervals.apply(lambda r: period_interval.overlaps(r))
+        files_in_range = intervals.overlaps(period_interval)
 
-        if len(df[files_in_range]) == 0:
+        if not files_in_range.any():
             logging.warning(
-                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage (no files in range)."
+                f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage (no files in range {period})."
             )
             return pd.DataFrame(columns=df.columns)
 
@@ -961,38 +951,24 @@ def subset_file_coverage(
         # without having to open the files or checking day-by-day
         if coverage > 0:
             # Number of hours in the requested period
-            period_nb_hrs = date_parser(
-                period[1], end_of_period=True, freq="H"
-            ) - date_parser(period[0], freq="H")
-
+            period_length = period_interval.length
             # Sum of hours in all selected files, restricted by the requested period
-            guessed_nb_hrs_sum = (
-                df[files_in_range].apply(
-                    lambda x: np.min(
-                        [
-                            x["date_end"],
-                            date_parser(period[1], end_of_period=True, freq="H"),
-                        ]
-                    ),
-                    axis=1,
-                )
-                - df[files_in_range].apply(
-                    lambda x: np.max(
-                        [x["date_start"], date_parser(period[0], freq="H")]
-                    ),
-                    axis=1,
-                )
-            ).sum()
+            guessed_length = pd.IntervalIndex.from_arrays(
+                intervals[files_in_range].map(
+                    lambda x: max(x.left, period_interval.left)
+                ),
+                intervals[files_in_range].map(
+                    lambda x: min(x.right, period_interval.right)
+                ),
+            ).length
 
-            if guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos < coverage:
+            if guessed_length / period_length < coverage:
                 logging.warning(
                     f"{df['id'].iloc[0] + ': ' if 'id' in df.columns else ''}Insufficient coverage "
-                    f"(guessed at {guessed_nb_hrs_sum.nanos / period_nb_hrs.nanos:.1%})."
+                    f"(guessed at {guessed_length / period_length:.1%})."
                 )
                 return pd.DataFrame(columns=df.columns)
 
-            files_to_keep = files_to_keep | files_in_range
-        else:
-            files_to_keep = files_to_keep | files_in_range
+        files_to_keep.append(files_in_range)
 
-    return df[files_to_keep]
+    return df[reduce(or_, files_to_keep)]


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* The `date_start` and  `date_end` columns are casted with a `datetime64[ms]` dtype (not a Period)
* Improvements to `date_parser`.
* Rewrite of `subset_file_coverage`.
* Removal of `driving_institution` as an official xscen column.
* pin of pandas >= 2

Pandas 2 now supports datetime columns with a s, ms and us resolution, instead of the old ns default. This allows storing dates from before 1677 and after 2242. However, this support is still partial as many of the datetime manipulation methods will still fail on "out of bounds" dates. This includes: `pd.read_csv` and `pd.to_datetime`... Because of this bug, I had to implement the parsing directly in the `DataCatalog`'s init, using a solution proposed [on stackoverflow](https://stackoverflow.com/a/76613404/9291575).

Even with this strange workaround, opening `simulation.json` went from 3 s to 800 ms on my machine !

The change had repercussions in other parts of xscen, especially `date_parser` and `subset_file_coverage`. I adapted the former to output `pd.Timestamp` objects by default and the latter to use more of the `Interval` magic pandas can already do with datetime bounds.

I also used this PR to remove `driving_institution` from the official columns, as discussed.

### Does this PR introduce a breaking change?
The default output of `date_parser` has changed.

The default dtype of `date_start` and `date_end` has changed.

The `driving_institution` column has been removed.

### Other information:
This required pinning pandas >= 2, clisops >= 0.10. The latter pin allowed unpinning python. 
