### PR TITLE
Tests for aggregate and indicators

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,12 +23,14 @@ Breaking changes
 * The default output of ``date_parser`` is now ``pd.Timestamp`` (``output_dtype='datetime'``). (:pull:`222`).
 * ``driving_institution`` was removed from the "default" xscen columns. (:pull:`222`).
 * Folder parsing utilities (``parse_directory``) moved to ``xscen.catutils``. Signature changed : ``globpattern`` removed, ``dirglob`` added, new ``patterns`` specifications. See doc for all changes. (:pull:`205`).
+* ``compute_indicators`` now returns all outputs produced by indicators with multiple outputs (such as `rain_season`). (:pull:`228`).
 
 Bug fixes
 ^^^^^^^^^
 * Fix bug in ``unstack_dates`` with seasonal climatological mean. (:issue:`202`, :pull:`202`).
 * Added NotImplemented errors when trying to call `climatological_mean` and `compute_deltas` with daily data. (:pull:`187`).
 * Minor documentation fixes. (:issue:`223`, :pull:`225`).
+* Fixed a bug in ``unstack_dates`` where it failed for anything other than seasons. (:pull:`228`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -39,6 +41,8 @@ Internal changes
 * Updated GitHub Actions to remove deprecation warnings. (:pull:`187`).
 * Updated the cookiecutter used to generate boilerplate documentation and code via `cruft`. (:pull:`212`).
 * A few changes to `subset_warming_level` so it doesn't need `driving_institution`. (:pull:`215`).
+* Added more tests. (:pull:`228`).
+* In ``compute_indicators``, the logic to manage indicators returning multiple outputs was simplified. (:pull:`228`).
 
 v0.6.0 (2023-05-04)
 -------------------

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -201,7 +201,7 @@ class TestComputeDeltas:
         # Test metadata
         assert (
             deltas[variable].attrs["description"]
-            == f"{self.ds.tas.attrs['description']}: {delta_kind} delta compared to 1981_2010."
+            == f"{self.ds.tas.attrs['description']}: {delta_kind} delta compared to 1981-2010."
         )
         assert f"{delta_kind} delta vs. 1981-2010" in deltas[variable].attrs["history"]
         # Test variable

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,9 +1,12 @@
 import numpy as np
 import pytest
 import xarray as xr
+import xclim
 from xclim.testing.helpers import test_timeseries as timeseries
 
 import xscen as xs
+
+from .conftest import notebooks
 
 
 class TestClimatologicalMean:
@@ -138,3 +141,297 @@ class TestClimatologicalMean:
 
         out = xs.climatological_mean(ds.convert_calendar(cal, align_on="date"))
         assert out.time.dt.calendar == cal
+
+
+class TestComputeDeltas:
+    ds = xs.climatological_mean(
+        timeseries(
+            np.repeat(np.arange(1, 5), 30).astype(float),
+            variable="tas",
+            start="1981-01-01",
+            freq="YS",
+            as_dataset=True,
+        ),
+        window=30,
+        interval=30,
+    )
+
+    @pytest.mark.parametrize(
+        "kind, rename_variables, to_level",
+        [("+", True, None), ("/", False, "for_testing"), ("%", True, "for_testing")],
+    )
+    def test_options(self, kind, rename_variables, to_level):
+        if to_level is None:
+            deltas = xs.compute_deltas(
+                self.ds,
+                reference_horizon="1981-2010",
+                kind=kind,
+                rename_variables=rename_variables,
+            )
+        else:
+            deltas = xs.compute_deltas(
+                self.ds,
+                reference_horizon="1981-2010",
+                kind=kind,
+                rename_variables=rename_variables,
+                to_level=to_level,
+            )
+
+        variable = "tas_delta_1981_2010" if rename_variables else "tas"
+        delta_kind = (
+            "absolute" if kind == "+" else "relative" if kind == "/" else "percentage"
+        )
+        results = (
+            [0, 1, 2, 3]
+            if kind == "+"
+            else [1, 2, 3, 4]
+            if kind == "/"
+            else [0, 100, 200, 300]
+        )
+        units = "K" if kind == "+" else "" if kind == "/" else "%"
+
+        # Test rename_variables and to_level
+        assert variable in deltas.data_vars
+        assert len(deltas.data_vars) == 1
+        assert deltas.attrs["cat:processing_level"] == (
+            "for_testing"
+            if to_level is not None
+            else f"delta_{self.ds.attrs['cat:processing_level']}"
+        )
+        # Test metadata
+        assert (
+            deltas[variable].attrs["description"]
+            == f"{self.ds.tas.attrs['description']}: {delta_kind} delta compared to 1981_2010."
+        )
+        assert f"{delta_kind} delta vs. 1981-2010" in deltas[variable].attrs["history"]
+        # Test variable
+        assert deltas[variable].attrs["delta_kind"] == delta_kind
+        assert deltas[variable].attrs["delta_reference"] == "1981-2010"
+        assert deltas[variable].attrs["units"] == units
+        np.testing.assert_array_equal(deltas[variable], results)
+
+    @pytest.mark.parametrize("cal", ["proleptic_gregorian", "noleap", "360_day"])
+    def test_calendars(self, cal):
+        out = xs.compute_deltas(
+            self.ds.convert_calendar(cal, align_on="date"),
+            reference_horizon="1981-2010",
+        )
+        assert out.time.dt.calendar == cal
+
+    def test_input_ds(self):
+        out1 = xs.compute_deltas(
+            self.ds,
+            reference_horizon=self.ds.where(self.ds.horizon == "1981-2010", drop=True),
+        )
+        out2 = xs.compute_deltas(self.ds, reference_horizon="1981-2010")
+        assert out1.equals(out2)
+
+    @pytest.mark.parametrize("xrfreq", ["MS", "QS", "AS-JAN"])
+    def test_freqs(self, xrfreq):
+        o = 12 if xrfreq == "MS" else 4 if xrfreq == "QS" else 1
+
+        ds = xs.climatological_mean(
+            timeseries(
+                np.repeat(np.arange(1, 5), 30 * o).astype(float),
+                variable="tas",
+                start="1981-01-01",
+                freq=xrfreq,
+                as_dataset=True,
+            ),
+            window=30,
+            interval=30,
+        )
+
+        out = xs.compute_deltas(
+            ds, reference_horizon="1981-2010", rename_variables=False
+        )
+        assert len(out.time) == o * len(np.unique(out.horizon.values))
+        results = np.repeat(np.arange(0, 4), o)
+        np.testing.assert_array_equal(out.tas, results)
+
+    def test_fx(self):
+        ds = timeseries(
+            np.arange(1, 5),
+            variable="tas",
+            start="1981-01-01",
+            freq="30YS",
+            as_dataset=True,
+        )
+        ds["horizon"] = xr.DataArray(
+            ["1981-2010", "2011-2040", "2041-2070", "2071-2100"], dims=["time"]
+        )
+        ds = ds.swap_dims({"time": "horizon"}).drop("time")
+
+        out = xs.compute_deltas(
+            ds, reference_horizon="1981-2010", rename_variables=False
+        )
+        np.testing.assert_array_equal(out.tas, np.arange(0, 4))
+        out2 = xs.compute_deltas(
+            ds,
+            reference_horizon=ds.sel(horizon="1981-2010"),
+            kind="+",
+            rename_variables=False,
+        )
+        assert out.equals(out2)
+
+    def test_errors(self):
+        # Multiple horizons in reference
+        with pytest.raises(ValueError):
+            xs.compute_deltas(
+                self.ds,
+                reference_horizon=self.ds.where(
+                    self.ds.horizon.isin(["1981-2010", "2011-2040"]), drop=True
+                ),
+            )
+        # Unknown reference horizon
+        with pytest.raises(ValueError):
+            xs.compute_deltas(self.ds, reference_horizon="1981-2010-2030")
+        with pytest.raises(ValueError):
+            xs.compute_deltas(self.ds, reference_horizon=5)
+        # Unknown reference horizon format
+        with pytest.raises(ValueError):
+            xs.compute_deltas(
+                self.ds,
+                reference_horizon=self.ds.where(
+                    self.ds.horizon == "1981-2010", drop=True
+                )["tas"],
+            )
+        # Unknown kind
+        with pytest.raises(ValueError):
+            xs.compute_deltas(self.ds, reference_horizon="1981-2010", kind="unknown")
+        # Daily data
+        ds = timeseries(
+            np.tile(np.arange(0, 365), 3),
+            variable="tas",
+            start="2001-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds["horizon"] = ds.time.dt.year.astype(str)
+        with pytest.raises(NotImplementedError):
+            xs.compute_deltas(ds, reference_horizon="2001")
+
+
+class TestProduceHorizon:
+    ds = timeseries(
+        np.ones(365 * 30 + 7),
+        variable="tas",
+        start="1981-01-01",
+        freq="D",
+        as_dataset=True,
+    )
+
+    yaml_file = notebooks / "samples" / "indicators.yml"
+
+    @pytest.mark.parametrize(
+        "period, to_level",
+        [
+            (None, None),
+            (["1995", "2007"], "for_testing"),
+            (["1995", "1996"], "for_testing"),
+        ],
+    )
+    def test_options(self, period, to_level):
+        if to_level is None:
+            out = xs.produce_horizon(self.ds, indicators=self.yaml_file, period=period)
+        else:
+            out = xs.produce_horizon(
+                self.ds, indicators=self.yaml_file, period=period, to_level=to_level
+            )
+
+        assert "time" not in out.dims
+        assert len(out.horizon) == 1
+        assert out.horizon.item() == (
+            "1981-2010" if period is None else "-".join(period)
+        )
+        assert out.attrs["cat:processing_level"] == (
+            "for_testing"
+            if to_level is not None
+            else f"climatology{out.horizon.item()}"
+        )
+        assert out.attrs["cat:xrfreq"] == "fx"
+        assert all(v in out for v in ["tg_min", "growing_degree_days"])
+        assert (
+            f"{30 if period is None else int(period[1]) - int(period[0]) + 1}-year mean of"
+            in out.tg_min.attrs["description"]
+        )
+        assert (
+            out.tg_min.attrs["description"].split(
+                f"{30 if period is None else int(period[1]) - int(period[0]) + 1}-year mean of "
+            )[1]
+            != self.ds.tas.attrs["description"]
+        )
+        np.testing.assert_array_equal(out.tg_min, [1])
+        np.testing.assert_array_equal(out.growing_degree_days, [0])
+
+    def test_multiple_freqs(self):
+        ds = timeseries(
+            np.ones(365 * 30 + 7),
+            variable="tas",
+            start="1981-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds["tas"] = ds["tas"].convert_calendar("noleap", align_on="date")
+        # Overwrite values to make them equal to the month
+        ds["tas"].values = ds["time"].dt.month
+        ds["da"] = ds["tas"]
+
+        indicator_qs = xclim.core.indicator.Indicator.from_dict(
+            data={"base": "tg_min", "parameters": {"freq": "QS-DEC"}},
+            identifier="tg_min_qs",
+            module="tests",
+        )
+        indicator_ms = xclim.core.indicator.Indicator.from_dict(
+            data={"base": "tg_min", "parameters": {"freq": "MS"}},
+            identifier="tg_min_ms",
+            module="tests",
+        )
+
+        indicators = [
+            ("fit", xclim.indicators.generic.fit),
+            ("tg_min_as", xclim.indicators.atmos.tg_min),
+            ("tg_min_qs", indicator_qs),
+            ("tg_min_ms", indicator_ms),
+        ]
+
+        out = xs.produce_horizon(ds, indicators=indicators)
+        assert len(out.horizon) == 1
+        assert all(v in out for v in ["params", "tg_min", "tg_min_qs", "tg_min_ms"])
+        np.testing.assert_array_equal(out["season"], ["MAM", "JJA", "SON", "DJF"])
+        np.testing.assert_array_equal(
+            out["month"],
+            [
+                "JAN",
+                "FEB",
+                "MAR",
+                "APR",
+                "MAY",
+                "JUN",
+                "JUL",
+                "AUG",
+                "SEP",
+                "OCT",
+                "NOV",
+                "DEC",
+            ],
+        )
+        np.testing.assert_array_almost_equal(
+            out["params"].squeeze(), [6.523, 3.449], decimal=3
+        )
+        np.testing.assert_array_equal(out["tg_min"].squeeze(), [1])
+        np.testing.assert_array_equal(out["tg_min_qs"].squeeze(), [3, 6, 9, 1])
+        np.testing.assert_array_equal(out["tg_min_ms"].squeeze(), np.arange(1, 13))
+
+    def test_warminglevel(self):
+        ds = self.ds.copy().expand_dims({"warminglevel": ["+1Cvs1850-1900"]})
+        out = xs.produce_horizon(ds, indicators=self.yaml_file)
+        np.testing.assert_array_equal(out["horizon"], ds["warminglevel"])
+        assert out.attrs["cat:processing_level"] == "climatology1981-2010"
+
+        # Multiple warming levels
+        ds = self.ds.copy().expand_dims(
+            {"warminglevel": ["+1Cvs1850-1900", "+2Cvs1850-1900"]}
+        )
+        with pytest.raises(ValueError):
+            xs.produce_horizon(ds, indicators=self.yaml_file)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -12,9 +12,8 @@ from .conftest import notebooks
 
 class TestComputeIndicators:
     yaml_file = notebooks / "samples" / "indicators.yml"
-    values = np.ones(365 * 3)
     ds = timeseries(
-        values, variable="tas", start="2001-01-01", freq="D", as_dataset=True
+        np.ones(365 * 3), variable="tas", start="2001-01-01", freq="D", as_dataset=True
     )
 
     @pytest.mark.parametrize("reload", [True, False])

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,130 @@
+import warnings
+
+import numpy as np
+import pytest
+import xclim
+from xclim.testing.helpers import test_timeseries as timeseries
+
+import xscen as xs
+
+from .conftest import notebooks
+
+
+class TestComputeIndicators:
+    yaml_file = notebooks / "samples" / "indicators.yml"
+    values = np.ones(365 * 3)
+    ds = timeseries(
+        values, variable="tas", start="2001-01-01", freq="D", as_dataset=True
+    )
+
+    @pytest.mark.parametrize("reload", [True, False])
+    def test_reload_module(self, reload):
+        module = xs.indicators.load_xclim_module(self.yaml_file)
+        assert all(hasattr(module, ind) for ind in ["growing_degree_days", "tg_min"])
+
+        # Record warnings without failing the test if no warnings are raised.
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            xs.indicators.load_xclim_module(
+                notebooks / "samples" / "indicators", reload=reload
+            )
+        assert len(
+            [
+                r
+                for r in record
+                if "already exists and will be overwritten." in str(r.message)
+            ]
+        ) == (2 if reload else 0)
+
+    @pytest.mark.parametrize("input", ["module", "iter"])
+    def test_input_types(self, input):
+        module = xs.indicators.load_xclim_module(self.yaml_file)
+        ind_dict1 = xs.compute_indicators(
+            self.ds,
+            indicators=module if input == "module" else module.iter_indicators(),
+        )
+        ind_dict2 = xs.compute_indicators(self.ds, indicators=self.yaml_file)
+        assert all(ind_dict1[k].equals(ind_dict2[k]) for k in ind_dict1)
+
+    @pytest.mark.parametrize("to_level", [None, "test"])
+    def test_level(self, to_level):
+        if to_level is None:
+            ind_dict = xs.compute_indicators(self.ds, indicators=self.yaml_file)
+            assert "indicators" in ind_dict["AS-JAN"].attrs["cat:processing_level"]
+        else:
+            ind_dict = xs.compute_indicators(
+                self.ds, indicators=self.yaml_file, to_level=to_level
+            )
+            assert to_level in ind_dict["AS-JAN"].attrs["cat:processing_level"]
+
+    # Periods needed to cover both branches of the if/else in compute_indicators, so no need to test separately.
+    @pytest.mark.parametrize(
+        "periods", [None, [["2001", "2001"], ["2003", "2004"], ["2005", "2009"]]]
+    )
+    def test_output(self, periods):
+        values = np.ones(365 * (2 if periods is None else 10))
+        ds = timeseries(
+            values, variable="tas", start="2001-01-01", freq="D", as_dataset=True
+        )
+        ds["da"] = ds.tas
+
+        module = xs.indicators.load_xclim_module(self.yaml_file)
+        ind_dict = xs.compute_indicators(
+            ds,
+            indicators=[("fit", xclim.indicators.generic.fit)]
+            + [x for x in module.iter_indicators()],
+            periods=periods,
+        )
+        assert all(
+            xrfreq in ind_dict[xrfreq].attrs["cat:xrfreq"] for xrfreq in ind_dict.keys()
+        )
+        assert all(v in ind_dict["AS-JAN"] for v in ["tg_min", "growing_degree_days"])
+        if periods is None:
+            assert "time" not in ind_dict["fx"].dims
+            assert len(ind_dict["AS-JAN"].time) == 2
+        else:
+            assert len(ind_dict["fx"].time) == len(periods)
+            assert len(ind_dict["AS-JAN"].time) == 8
+
+    def test_qs_dec(self):
+        indicator = xclim.core.indicator.Indicator.from_dict(
+            data={"base": "tg_min", "parameters": {"freq": "QS-DEC"}},
+            identifier="tg_min_qs",
+            module="tests",
+        )
+        ind_dict = xs.compute_indicators(self.ds, indicators=[("tg_min_qs", indicator)])
+        assert "QS-DEC" in ind_dict["QS-DEC"].attrs["cat:xrfreq"]
+        assert len(ind_dict["QS-DEC"].time) == 12
+        assert ind_dict["QS-DEC"].time[0].dt.strftime("%Y-%m-%d").item() == "2001-03-01"
+        assert (
+            ind_dict["QS-DEC"].time[-1].dt.strftime("%Y-%m-%d").item() == "2003-12-01"
+        )
+
+    # Periods needed to cover both branches of the if/else in compute_indicators, so no need to test separately.
+    @pytest.mark.parametrize("periods", [None, [["2001", "2001"], ["2003", "2003"]]])
+    def test_multiple_outputs(self, periods):
+        values = np.zeros(365 * 3)
+        values[150:250] = 100
+        values[150 + 365 : 250 + 365] = 100
+        values[150 + 365 * 2 : 250 + 365 * 2] = 100
+        ds = timeseries(
+            values, variable="pr", start="2001-01-01", freq="D", as_dataset=True
+        )
+        ind_dict = xs.compute_indicators(
+            ds,
+            indicators=[
+                ("precip", xclim.atmos.precip_average),
+                ("rs", xclim.atmos.rain_season),
+            ],
+            periods=periods,
+        )
+
+        assert all(
+            v in ind_dict["AS-JAN"]
+            for v in [
+                "prcpavg",
+                "rain_season_start",
+                "rain_season_end",
+                "rain_season_length",
+            ]
+        )

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -311,7 +311,7 @@ def compute_deltas(
             if hasattr(other_hz[vv], a):
                 deltas[v_name].attrs[
                     a
-                ] = f"{other_hz[vv].attrs[a]}: {_kind} delta compared to {reference_horizon.replace('-', '_')}."
+                ] = f"{other_hz[vv].attrs[a]}: {_kind} delta compared to {reference_horizon}."
 
         new_history = f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {_kind} delta vs. {reference_horizon} - xarray v{xr.__version__}"
         history = (

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -897,7 +897,7 @@ def unstack_dates(
             "to pad missing dates and reset the time coordinate."
         )
     first, last = ds.indexes["time"][[0, -1]]
-    use_cftime = xr.coding.times.contains_cftime_datetimes(ds.time)
+    use_cftime = xr.coding.times.contains_cftime_datetimes(ds.time.variable)
     calendar = ds.time.dt.calendar
     mult, base, isstart, anchor = parse_offset(freq)
 
@@ -979,7 +979,7 @@ def unstack_dates(
         # Replace (A,'time',B) by (A,'time', 'season',B) in both the new shape and the new dims
         new_dims = list(
             chain.from_iterable(
-                [d] if d != "time" else ["time", "season"] for d in da.dims
+                [d] if d != "time" else ["time", new_dim] for d in da.dims
             )
         )
         new_shape = [len(new_coords[d]) for d in new_dims]


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Tests for multiple functions in `aggregate.py` and `indicators.py`.
* Minor bugfixes when detected by the tests (yay!).
* Changed a couple `PosixPath` to just `Path`
* Fixed a bug in `unstack_dates` where it failed for anything other than seasons.
* Fixed a bug in `unstack_dates` related to `xr.coding.times.contains_cftime_datetimes` in the newest `xarray`: https://github.com/pydata/xarray/issues/7966 
* The logic to manage indicators returning multiple outputs (such as `rain_season`), was changed a little and was completely broken anyway (oops). We now keep all variables produced and move from a `DataArray` (or a tuple of `DataArray`) to a `Dataset` much earlier, which makes everything else simpler to manage.

### Does this PR introduce a breaking change?

* I got rid of `out_dict[key] = xr.merge(o for o in out if o.name in indicators)` in `compute_indicators`, in favor of returning all variables. Previously, `xs.compute_indicators(ds,  indicators=[("rs", xclim.atmos.rain_season)])` would return an empty Dataset, because `rs` doesn't correspond to any of the outputs. Similarly, `xs.compute_indicators(ds,  indicators=[("rain_season_start", xclim.atmos.rain_season)])` would only return 1 out of 3 outputs produced by xclim. This is more a bugfix than a breaking change, but might still break some workflows.

### Other information:

* I did not add tests to `aggregate.spatial_mean`, since changes are coming soon to xESMF, including some bugfixes that will affect that function.
