### PR TITLE
Stricter build_path / better end_of_period

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,7 @@ New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * `xscen` now tracks code coverage using `coveralls <https://coveralls.io/>`_. (:pull:`187`).
 * New function `get_warming_level` to search within the IPCC CMIP global temperatures CSV without requiring data. (:issue:`208`, :pull:`210`).
-* File re-structuration from catalogs with ``xscen.catutils.build_path``. (:pull:`205`).
+* File re-structuration from catalogs with ``xscen.catutils.build_path``. (:pull:`205`, :pull:`237`).
 * New scripting functions `save_and_update` and `move_and_delete`. (:pull:`214`).
 * Spatial dimensions can be generalized as X/Y when rechunking and will be mapped to rlon/rlat or lon/lat accordingly. (:pull:`221`).
 * New argument `var_as_string` for `get_cat_attrs` to return variable names as strings. (:pull:`233`).
@@ -29,6 +29,7 @@ Breaking changes
 ^^^^^^^^^^^^^^^^
 * Columns ``date_start`` and ``date_end`` now use a ``datetime64[ms]`` dtype. (:pull:`222`).
 * The default output of ``date_parser`` is now ``pd.Timestamp`` (``output_dtype='datetime'``). (:pull:`222`).
+* ``date_parser(date, end_of_period=True)`` has time "23:59:59", instead of "23:00". (:pull:`222`, :pull:`237`).
 * ``driving_institution`` was removed from the "default" xscen columns. (:pull:`222`).
 * Folder parsing utilities (``parse_directory``) moved to ``xscen.catutils``. Signature changed : ``globpattern`` removed, ``dirglob`` added, new ``patterns`` specifications. See doc for all changes. (:pull:`205`).
 * ``compute_indicators`` now returns all outputs produced by indicators with multiple outputs (such as `rain_season`). (:pull:`228`).

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -250,6 +250,6 @@ def test_build_path_multivar(samplecat):
     info["variable"] = ("tas", "tasmin")
     with pytest.raises(
         ValueError,
-        match="Selected schema raw-sims-raw is meant to be used with single-variable datasets.",
+        match="Selected schema original-sims-raw is meant to be used with single-variable datasets.",
     ):
         cu.build_path(info)

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -250,6 +250,6 @@ def test_build_path_multivar(samplecat):
     info["variable"] = ("tas", "tasmin")
     with pytest.raises(
         ValueError,
-        match="Selected schema raw-sims is meant to be used with single-variable datasets.",
+        match="Selected schema raw-sims-raw is meant to be used with single-variable datasets.",
     ):
         cu.build_path(info)

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -23,6 +23,10 @@ class TestScripting:
         "cat:source": "CanESM5",
         "cat:experiment": "ssp585",
         "cat:member": "r1i1p1f1",
+        "cat:domain": "global",
+        "cat:mip_era": "CMIP6",
+        "cat:institution": "CCCma",
+        "cat:activity": "ScenarioMIP",
     }
 
     def test_save_and_update(self):
@@ -50,7 +54,7 @@ class TestScripting:
         assert (
             cat.df.path[1]
             == root
-            + "/simulation/raw/CanESM5/ssp585/r1i1p1f1/yr/tas/tas_yr_CanESM5_ssp585_r1i1p1f1_2000-2049.nc"
+            + "/simulation/raw/CMIP6/ScenarioMIP/global/CCCma/CanESM5/ssp585/r1i1p1f1/yr/tas/tas_yr_CMIP6_ScenarioMIP_global_CCCma_CanESM5_ssp585_r1i1p1f1_2000-2049.nc"
         )
         assert cat.df.source[1] == "CanESM5"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,8 @@ class TestDateParser:
     @pytest.mark.parametrize(
         "date,end_of_period,dtype,exp",
         [
-            ("2001", True, "datetime", pd.Timestamp("2001-12-31")),
-            ("150004", True, "datetime", pd.Timestamp("1500-04-30")),
+            ("2001", True, "datetime", pd.Timestamp("2001-12-31 23:59:59")),
+            ("150004", True, "datetime", pd.Timestamp("1500-04-30 23:59:59")),
             ("31231212", None, "datetime", pd.Timestamp("3123-12-12")),
             ("2001-07-08", None, "period", pd.Period("2001-07-08", "H")),
             (pd.Timestamp("1993-05-20T12:07"), None, "str", "1993-05-20"),
@@ -24,7 +24,12 @@ class TestDateParser:
                 "datetime",
                 pd.Timestamp("1981-02-28"),
             ),
-            (np.datetime64("1200-11-12"), "Y", "datetime", pd.Timestamp("1200-12-31")),
+            (
+                np.datetime64("1200-11-12"),
+                "Y",
+                "datetime",
+                pd.Timestamp("1200-12-31 23:59:59"),
+            ),
             (
                 datetime(2045, 5, 2, 13, 45),
                 None,

--- a/xscen/catutils.py
+++ b/xscen/catutils.py
@@ -13,7 +13,7 @@ from fnmatch import fnmatch
 from functools import partial, reduce
 from multiprocessing import Pool
 from pathlib import Path, PosixPath
-from typing import Any, Optional, Union
+from typing import Any, Optional, Tuple, Union
 
 import cftime
 import netCDF4
@@ -834,7 +834,7 @@ def _parse_from_nc(path: os.PathLike, get_vars=True, get_time=True):
 # ## Path building ## #
 def _schema_option(option: dict, facets: dict):
     """Parse an option element of the facet schema tree."""
-    facet_value = facets.get(option["option"])
+    facet_value = facets.get(option["facet"])
     if "value" in option:
         if isinstance(option["value"], str):
             answer = facet_value == option["value"]
@@ -842,22 +842,26 @@ def _schema_option(option: dict, facets: dict):
             answer = facet_value in option["value"]
     else:
         answer = not isna(facet_value)
-
-    if "is_true" in option and answer:
-        return option["is_true"]
-    if "else" in option and not answer:
-        return option["else"]
     return answer
 
 
 def _schema_level(schema: Union[dict, str], facets: dict):
     if isinstance(schema, str):
+        if schema.startswith("(") and schema.endswith(")"):
+            optional = True
+            schema = schema[1:-1]
+        else:
+            optional = False
         if schema == "DATES":
-            return _schema_dates(facets)
+            return _schema_dates(facets, optional=optional)
 
         # A single facet:
         if isna(facets.get(schema)):
-            return None
+            if optional:
+                return None
+            raise ValueError(
+                f"Facet {schema} is needed but None-like or missing in the data."
+            )
         return facets[schema]
     if isinstance(schema, list):
         parts = []
@@ -866,39 +870,18 @@ def _schema_level(schema: Union[dict, str], facets: dict):
             if not isna(part):
                 parts.append(part)
         return "_".join(parts)
-    if "option" in schema:
-        answer = _schema_option(schema, facets)
-        if isinstance(answer, bool) and not answer:
-            # Test failed with no "else" value, we skip this level.
-            return None
-        return _schema_level(answer, facets)
-    if "text" in schema:
+    if isinstance(schema, dict) and "text" in schema:
         return schema["text"]
     raise ValueError(f"Invalid schema : {schema}")
 
 
-class KeyRecorder:
-    """A dummy object but recording requested keys.
-
-    Bracket-access (a[key]) returns the key as-is, but adds it to the `keys` property.
-    """
-
-    def __init__(self):
-        self.keys = set()
-
-    def __getitem__(self, k):
-        self.keys.add(k)
-        return k
-
-    def get(self, k):
-        return self[k]
-
-
-def _schema_dates(facets):
-    if isinstance(facets, KeyRecorder):
-        # Record that these three fields are needed
-        facets["date_start"], facets["date_end"], facets["xrfreq"]
-        return "dates"
+def _schema_dates(facets, optional=False):
+    if any([facets.get(f) is None for f in ["date_start", "date_end", "xrfreq"]]):
+        if optional:
+            return None
+        raise ValueError(
+            "Facets date_start, date_end and xrfreq are needed, but at least one is missing or None-like in the data."
+        )
 
     if facets["xrfreq"] == "fx":
         return "fx"
@@ -952,10 +935,19 @@ def _schema_folders(schema: list, facets: dict) -> list:
 
 def _get_needed_fields(schema: dict):
     """Return the list of facets that is needed for a given schema."""
-    facet_rec = KeyRecorder()
-    _schema_folders(schema["folders"], facet_rec)
-    _schema_filename(schema["filename"], facet_rec)
-    return facet_rec.keys
+    needed = set()
+    for level in schema["folders"]:
+        if isinstance(level, str):
+            if not (level.startswith("(") and level.endswith(")")):
+                needed.add(level)
+        elif isinstance(level, list):
+            for lvl in level:
+                needed.add(lvl)
+        elif not (isinstance(level, dict) and list(level.keys()) == ["text"]):
+            raise ValueError(
+                f"Invalid schema with unknown {level} of type {type(level)}."
+            )
+    return needed
 
 
 def _read_schemas(schemas):
@@ -982,9 +974,9 @@ def _build_path(
     data: Union[dict, xr.Dataset, xr.DataArray, pd.Series],
     schemas: dict,
     root: Path,
-    strict: bool = False,
+    get_type: bool = False,
     **extra_facets,
-) -> Path:
+) -> Union[Path, tuple[Path, str]]:
     # Get all known metadata
     if isinstance(data, (xr.Dataset, xr.DataArray)):
         facets = (
@@ -1021,7 +1013,7 @@ def _build_path(
         if match:
             # Checks
             needed_fields = _get_needed_fields(schema)
-            if strict and (missing_fields := needed_fields - set(facets.keys())):
+            if missing_fields := needed_fields - set(facets.keys()):
                 raise ValueError(
                     f"Missing facets {missing_fields} are needed to build the path according to selected schema {name}."
                 )
@@ -1036,7 +1028,9 @@ def _build_path(
                 out = root / out
             if "format" in facets:  # Add extension
                 # Can't use `with_suffix` in case there are dots in the name
-                return out.parent / f"{out.name}.{facets['format']}"
+                out = out.parent / f"{out.name}.{facets['format']}"
+            if get_type:
+                return out, name
             return out
 
     raise ValueError(f"This file doesn't match any schema. Facets:\n{facets}")
@@ -1047,7 +1041,6 @@ def build_path(
     data: Union[dict, xr.Dataset, xr.DataArray, pd.Series, DataCatalog, pd.DataFrame],
     schemas: Optional[Union[str, os.PathLike, list[dict], dict]] = None,
     root: os.PathLike = None,
-    strict: bool = False,
     **extra_facets,
 ) -> Union[Path, DataCatalog, pd.DataFrame]:
     """Parse the schema from a configuration and construct path using a dictionary of facets.
@@ -1066,9 +1059,6 @@ def build_path(
         Or a single schema dict (single element of the yaml).
     root : Path, optional
         If given, the generated path(s) is given under this root one.
-    strict : bool
-        If True, the data must include all facets referred in the schema.
-        If False (default), the output paths might be inconsistent if some fields are missing.
     extra_facets : str
         Extra facets to supplement or override metadadata missing from the first input.
 
@@ -1077,6 +1067,7 @@ def build_path(
     Path or catalog
         Constructed path. If "format" is absent from the facets, it has no suffix.
         If `data` was a catalog, a copy with a "new_path" column is returned.
+        Another "new_path_type" column is also added if `schemas` was a collection of schemas (like the default).
 
     Examples
     --------
@@ -1100,13 +1091,17 @@ def build_path(
 
         df = df.copy()
 
-        df["new_path"] = df.apply(
+        paths = df.apply(
             _build_path,
             axis=1,
+            result_type="expand",
             schemas=schemas,
             root=root,
-            strict=strict,
+            get_type=True,
             **extra_facets,
-        ).apply(str)
+        )
+        df["new_path"] = paths[0].apply(str)
+        if len(schemas) > 1:
+            df["new_path_type"] = paths[1]
         return df
-    return _build_path(data, schemas=schemas, root=root, **extra_facets)
+    return _build_path(data, schemas=schemas, root=root, get_type=False, **extra_facets)

--- a/xscen/data/file_schema.yml
+++ b/xscen/data/file_schema.yml
@@ -124,7 +124,7 @@ raw-hydro-sims-ba:
     - facet: type
       value: simulation-hydro
     - facet: processing_level
-      value: [ rbiasadjusted ]
+      value: [ biasadjusted ]
   folders:
     - type
     - hydrology_project

--- a/xscen/data/file_schema.yml
+++ b/xscen/data/file_schema.yml
@@ -266,4 +266,4 @@ derived-hydro-reconstruction:
     - processing_level
     - xrfreq
     - variable
-  filename: [ variable, xrfreq, hydrology_project, hydrology_institution, hydrology_source, institution, source, version, member, domain, processing_level, DATES ]
+  filename: [ variable, xrfreq, hydrology_project, hydrology_source, hydrology_member, institution, source, version, member, domain, processing_level, DATES ]

--- a/xscen/data/file_schema.yml
+++ b/xscen/data/file_schema.yml
@@ -18,11 +18,11 @@
 #     filename: # The file name schema, a list of facet names. If a facet is empty, it will be skipped. Elements will be separated by "_".
 #               # The special "DATES" facet will be replaced by the most concise way found to define the temporal range covered by the file.
 ---
-### Raw data
+### Original / raw data
 #
-# These schemas are meant for raw-like data, usually hourly or daily, used as input for scenario projects.
-# It includes bias-adjusted datasets.
-raw-non-sims:
+# These schemas are meant for primary data, usually hourly or daily, used as input for scenario projects.
+# It usually includes datasets with processing_level "raw" or "biasadjusted
+original-non-sims:
   with:
     - facet: type
       value: [station-obs, reconstruction, forecast]
@@ -37,7 +37,7 @@ raw-non-sims:
     - frequency
     - variable
   filename: [ variable, frequency, domain, institution, source, version, member, DATES ]
-raw-sims-raw:
+original-sims-raw:
   with:
     - facet: type
       value: simulation
@@ -57,7 +57,7 @@ raw-sims-raw:
     - frequency
     - variable
   filename: [ variable, frequency, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
-raw-sims-ba:
+original-sims-ba:
   with:
     - facet: type
       value: simulation
@@ -78,7 +78,7 @@ raw-sims-ba:
     - frequency
     - variable
   filename: [ variable, frequency, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
-raw-hydro-reconstruction:
+original-hydro-reconstruction:
   with:
     - facet: type
       value: reconstruction-hydro
@@ -88,15 +88,15 @@ raw-hydro-reconstruction:
     - type
     - domain
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - institution
     - [source, version]
     - (member)
     - frequency
     - variable
   filename: [ variable, frequency, domain, hydrology_project, hydrology_institution, hydrology_source, institution, source, version, member, DATES ]
-raw-hydro-sims-raw:
+original-hydro-sims-raw:
   with:
     - facet: type
       value: simulation-hydro
@@ -105,8 +105,8 @@ raw-hydro-sims-raw:
   folders:
     - type
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - processing_level
     - mip_era
     - activity
@@ -119,7 +119,7 @@ raw-hydro-sims-raw:
     - frequency
     - variable
   filename: [ variable, frequency, hydrology_project, hydrology_institution, hydrology_source,  bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
-raw-hydro-sims-ba:
+original-hydro-sims-ba:
   with:
     - facet: type
       value: simulation-hydro
@@ -128,8 +128,8 @@ raw-hydro-sims-ba:
   folders:
     - type
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - processing_level
     - [bias_adjust_project, version]
     - mip_era
@@ -213,8 +213,8 @@ derived-hydro-sims-ba:
   folders:
     - type
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - [bias_adjust_project, version]
     - mip_era
     - activity
@@ -235,8 +235,8 @@ derived-hydro-sims-raw:
   folders:
     - type
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - text: raw
     - mip_era
     - activity
@@ -257,8 +257,8 @@ derived-hydro-reconstruction:
   folders:
     - type
     - hydrology_project
-    - hydrology_institution
     - hydrology_source
+    - (hydrology_member)
     - institution
     - [source, version]
     - (member)

--- a/xscen/data/file_schema.yml
+++ b/xscen/data/file_schema.yml
@@ -5,17 +5,15 @@
 # Each top element may define the following fields:
 #
 #     with: # Section that decides if we use this element for the given file.
-#       - option: < facet >         # A facet and its values to match
+#       - facet: < facet >         # A facet and its values to match
 #         value: <value or values>  # this can be repeated
+#         # This schema will then be used if the facet <facet> is one of the values listed in <values>.
+#         # The absence of "value" means it is used if the facet <facet> is not empty.
 #     folders: # The path structure, each element is mapped to a folder level
 #       # There are four ways to specify a folder name to use:
-#       # Each way can be used recursively in place for < facet >.
-#       - < facet >           # If the facet is missing, this level is skipped, resulting in a tree of a different depth.
-#       - option: < facet >   # A test on the given facet's value.
-#         value: < value >    # Optional. If not given, the test is simple "facet is not empty"
-#         is_true: < facet >  # Optional. Facet to use if the test passes. If not given, this level is skipped resulting in a tree of a different depth.
-#         else: < facet > # Optional. Facet to use if the test fails. Same consequence as above if not given.
-#       - [< facet >, < facet >, ...]:  # The folder name consists in more than one facet, concatenated with a "_" by default.
+#       - < facet >           # The value of the facet.
+#       - (< facet >)         # Same, but if the facet is missing, this level is skipped, resulting in a tree of a different depth.
+#       - [< facet >, < facet >, ...]:  # The folder name consists in more than one facet, concatenated with a "_" by default. They can't be optional.
 #       - text: < value >     # A fixed string
 #     filename: # The file name schema, a list of facet names. If a facet is empty, it will be skipped. Elements will be separated by "_".
 #               # The special "DATES" facet will be replaced by the most concise way found to define the temporal range covered by the file.
@@ -26,36 +24,55 @@
 # It includes bias-adjusted datasets.
 raw-non-sims:
   with:
-    - option: type
+    - facet: type
       value: [station-obs, reconstruction, forecast]
-    - option: processing_level
+    - facet: processing_level
       value: raw
   folders:
     - type
     - domain
     - institution
     - [source, version]
-    - member
+    - (member)
     - frequency
     - variable
   filename: [ variable, frequency, domain, institution, source, version, member, DATES ]
-raw-sims:
+raw-sims-raw:
   with:
-    - option: type
+    - facet: type
       value: simulation
-    - option: processing_level
-      value: [ raw, biasadjusted ]
+    - facet: processing_level
+      value: [ raw ]
   folders:
     - type
     - processing_level
-    - option: bias_adjust_project
-      is_true: [bias_adjust_project, version]
     - mip_era
     - activity
     - domain
     - institution
     - source
-    - driving_model
+    - (driving_model)
+    - experiment
+    - member
+    - frequency
+    - variable
+  filename: [ variable, frequency, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
+raw-sims-ba:
+  with:
+    - facet: type
+      value: simulation
+    - facet: processing_level
+      value: [ biasadjusted ]
+  folders:
+    - type
+    - processing_level
+    - [bias_adjust_project, version]
+    - mip_era
+    - activity
+    - domain
+    - institution
+    - source
+    - (driving_model)
     - experiment
     - member
     - frequency
@@ -63,9 +80,9 @@ raw-sims:
   filename: [ variable, frequency, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
 raw-hydro-reconstruction:
   with:
-    - option: type
+    - facet: type
       value: reconstruction-hydro
-    - option: processing_level
+    - facet: processing_level
       value: raw
   folders:
     - type
@@ -75,35 +92,58 @@ raw-hydro-reconstruction:
     - hydrology_source
     - institution
     - [source, version]
-    - member
+    - (member)
     - frequency
     - variable
   filename: [ variable, frequency, domain, hydrology_project, hydrology_institution, hydrology_source, institution, source, version, member, DATES ]
-raw-hydro-sims:
+raw-hydro-sims-raw:
   with:
-    - option: type
+    - facet: type
       value: simulation-hydro
-    - option: processing_level
-      value: [ raw, biasadjusted ]
+    - facet: processing_level
+      value: [ raw ]
   folders:
     - type
     - hydrology_project
     - hydrology_institution
     - hydrology_source
     - processing_level
-    - option: bias_adjust_project
-      is_true: [bias_adjust_project, version]
     - mip_era
     - activity
     - domain
     - institution
     - source
-    - driving_model
+    - (driving_model)
     - experiment
     - member
     - frequency
     - variable
   filename: [ variable, frequency, hydrology_project, hydrology_institution, hydrology_source,  bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
+raw-hydro-sims-ba:
+  with:
+    - facet: type
+      value: simulation-hydro
+    - facet: processing_level
+      value: [ rbiasadjusted ]
+  folders:
+    - type
+    - hydrology_project
+    - hydrology_institution
+    - hydrology_source
+    - processing_level
+    - [bias_adjust_project, version]
+    - mip_era
+    - activity
+    - domain
+    - institution
+    - source
+    - (driving_model)
+    - experiment
+    - member
+    - frequency
+    - variable
+  filename: [ variable, frequency, hydrology_project, hydrology_institution, hydrology_source,  bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
+
 ### Derived data
 #
 # These schemas are meant for the output of scenario projects.
@@ -112,21 +152,38 @@ raw-hydro-sims:
 #     - domain denotes the zone over which the scenario was computed, not the original source's coverage
 #     - processing_level has more possible values, denoting slight variant of the data instead of broad categories.
 #     As such, both fields are here much lower in the hierarchy.
-derived-sims:
+derived-sims-ba:
   with:
-  - option: type
+  - facet: type
     value: simulation
+  - facet: bias_adjust_project
   folders:
     - type
-    - option: bias_adjust_project
-      is_true: [bias_adjust_project, version]
-      else:
-        text: raw
+    - [bias_adjust_project, version]
     - mip_era
     - activity
     - institution
     - source
-    - driving_model
+    - (driving_model)
+    - experiment
+    - member
+    - domain
+    - processing_level
+    - xrfreq
+    - variable
+  filename: [ variable, xrfreq, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
+derived-sims-raw:
+  with:
+  - facet: type
+    value: simulation
+  folders:
+    - type
+    - text: raw
+    - mip_era
+    - activity
+    - institution
+    - source
+    - (driving_model)
     - experiment
     - member
     - domain
@@ -136,36 +193,56 @@ derived-sims:
   filename: [ variable, xrfreq, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
 derived-reconstruction:
   with:
-    - option: type
+    - facet: type
       value: reconstruction
   folders:
     - type
     - institution
     - [source, version]
-    - member
+    - (member)
     - domain
     - processing_level
     - xrfreq
     - variable
   filename: [ variable, xrfreq, institution, source, version, member, domain, processing_level, DATES ]
-derived-hydro-sims:
+derived-hydro-sims-ba:
   with:
-  - option: type
+  - facet: type
+    value: simulation-hydro
+  - facet: bias_adjust_project
+  folders:
+    - type
+    - hydrology_project
+    - hydrology_institution
+    - hydrology_source
+    - [bias_adjust_project, version]
+    - mip_era
+    - activity
+    - institution
+    - source
+    - (driving_model)
+    - experiment
+    - member
+    - domain
+    - processing_level
+    - xrfreq
+    - variable
+  filename: [ variable, xrfreq, hydrology_project, hydrology_institution, hydrology_source, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
+derived-hydro-sims-raw:
+  with:
+  - facet: type
     value: simulation-hydro
   folders:
     - type
     - hydrology_project
     - hydrology_institution
     - hydrology_source
-    - option: bias_adjust_project
-      is_true: [bias_adjust_project, version]
-      else:
-        text: raw
+    - text: raw
     - mip_era
     - activity
     - institution
     - source
-    - driving_model
+    - (driving_model)
     - experiment
     - member
     - domain
@@ -175,7 +252,7 @@ derived-hydro-sims:
   filename: [ variable, xrfreq, hydrology_project, hydrology_institution, hydrology_source, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
 derived-hydro-reconstruction:
   with:
-    - option: type
+    - facet: type
       value: reconstruction-hydro
   folders:
     - type
@@ -184,7 +261,7 @@ derived-hydro-reconstruction:
     - hydrology_source
     - institution
     - [source, version]
-    - member
+    - (member)
     - domain
     - processing_level
     - xrfreq

--- a/xscen/data/file_schema.yml
+++ b/xscen/data/file_schema.yml
@@ -95,7 +95,7 @@ original-hydro-reconstruction:
     - (member)
     - frequency
     - variable
-  filename: [ variable, frequency, domain, hydrology_project, hydrology_institution, hydrology_source, institution, source, version, member, DATES ]
+  filename: [ variable, frequency, domain, hydrology_project, hydrology_source, hydrology_member, institution, source, version, member, DATES ]
 original-hydro-sims-raw:
   with:
     - facet: type
@@ -118,7 +118,7 @@ original-hydro-sims-raw:
     - member
     - frequency
     - variable
-  filename: [ variable, frequency, hydrology_project, hydrology_institution, hydrology_source,  bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
+  filename: [ variable, frequency, hydrology_project, hydrology_source, hydrology_member, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
 original-hydro-sims-ba:
   with:
     - facet: type
@@ -142,7 +142,7 @@ original-hydro-sims-ba:
     - member
     - frequency
     - variable
-  filename: [ variable, frequency, hydrology_project, hydrology_institution, hydrology_source,  bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
+  filename: [ variable, frequency, hydrology_project, hydrology_source, hydrology_member, bias_adjust_project, version, mip_era, activity, domain, institution, source, driving_model, experiment, member, DATES ]
 
 ### Derived data
 #
@@ -227,7 +227,7 @@ derived-hydro-sims-ba:
     - processing_level
     - xrfreq
     - variable
-  filename: [ variable, xrfreq, hydrology_project, hydrology_institution, hydrology_source, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
+  filename: [ variable, xrfreq, hydrology_project, hydrology_source, hydrology_member, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
 derived-hydro-sims-raw:
   with:
   - facet: type
@@ -249,7 +249,7 @@ derived-hydro-sims-raw:
     - processing_level
     - xrfreq
     - variable
-  filename: [ variable, xrfreq, hydrology_project, hydrology_institution, hydrology_source, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
+  filename: [ variable, xrfreq, hydrology_project, hydrology_source, hydrology_member, bias_adjust_project, version, mip_era, activity, institution, source, driving_model, experiment, member, domain, processing_level, DATES ]
 derived-hydro-reconstruction:
   with:
     - facet: type

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -129,10 +129,13 @@ def date_parser(
         date = pd.Timestamp(date)
 
     if isinstance(end_of_period, str) or (end_of_period is True and fmt):
+        quasiday = (pd.Timedelta(1, "d") - pd.Timedelta(1, "s")).as_unit(date.unit)
         if end_of_period == "Y" or "m" not in fmt:
-            date = pd.tseries.frequencies.to_offset("A-DEC").rollforward(date)
+            date = (
+                pd.tseries.frequencies.to_offset("A-DEC").rollforward(date) + quasiday
+            )
         elif end_of_period == "M" or "d" not in fmt:
-            date = pd.tseries.frequencies.to_offset("M").rollforward(date)
+            date = pd.tseries.frequencies.to_offset("M").rollforward(date) + quasiday
         # TODO: Implement subdaily ?
 
     if out_dtype == "str":


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Two different things, but that I both realized when updating the catalogs.

#### Stricter build_path
When I migrated from miranda, I relaxed the "structure" code because it felt too restricting and I wanted to simplify the logic. However, this wasn't a good idea. When moving the ESPO-R5-E5L indicators, I forgot to include the "experiment" field somewhere and used build_path to copy the files. Result : one scenario overwrote the other, I lost half of the data. 

This PR changes the things a bit, the main change being :  All facets, except those marked optional, are necessary. `build_path` will FAIL if any is missing.

And:
- New way to specific a folder level in the schema : "(<facet name>)" (with parenthesis). This facet is marked as optional and if it is missing from the data, the level is skipped.
- Removal of the "option: " structure from the folder schema. This was only used to put "[bias_adjust_project version]" if the former was non-null. Instead, the schemas are duplicated : one for the "raw" case and one for the "biasadjusted" case. (And similarly for derived data).
- The previous point allowed me to rewrite `_get_needed_fields` without the funcky magic needed before.
- Removal of the "strict" keyword. It is always strict. The previous `strict=True` was overly strict because of caveats of `_get_needed_fields`. Those are now fixed and `strict=False` shouldn't be needed.
- Some syntax in the yml file changed.
- Passing a dataframe/catalog will now also add a "new_path_type" column to the output, so one can make sure all entries have been constructed from the same schema.

#### Better end_of_period
When I updated pandas to 2, I modified `date_parser` and it changed how the "end_of_period" was handled.

```python
date_parser('2020', end_of_period=True)
# Initial xscen: "2020-12-31 23:00"
# Current xscen : "2020-12-31 00:00:00"
# This PR: "2020-12-31 23:59:59"
```
Thus, when searching for a coverage, the error due to the hour of the period end will be reduced.

### Does this PR introduce a breaking change?

`build_path` is now always strict.

### Other information:
Do you agree?

I could re-implement `strict=False` if needed. It would mark all fields as optional on-the-fly. The default would stay "True".
