### PR TITLE
Fix build_path for invariants

### DIFF
--- a/xscen/catutils.py
+++ b/xscen/catutils.py
@@ -885,7 +885,7 @@ def _schema_dates(facets, optional=False):
         raise ValueError(
             "Facets date_start, date_end and xrfreq are needed, but at least one is missing or None-like in the data."
         )
-    
+
     start = date_parser(facets["date_start"])
     end = date_parser(facets["date_end"])
     freq = pd.Timedelta(CV.xrfreq_to_timedelta(facets["xrfreq"]))

--- a/xscen/catutils.py
+++ b/xscen/catutils.py
@@ -876,16 +876,16 @@ def _schema_level(schema: Union[dict, str], facets: dict):
 
 
 def _schema_dates(facets, optional=False):
+    if facets.get("xrfreq") == "fx":
+        return "fx"
+
     if any([facets.get(f) is None for f in ["date_start", "date_end", "xrfreq"]]):
         if optional:
             return None
         raise ValueError(
             "Facets date_start, date_end and xrfreq are needed, but at least one is missing or None-like in the data."
         )
-
-    if facets["xrfreq"] == "fx":
-        return "fx"
-
+    
     start = date_parser(facets["date_start"])
     end = date_parser(facets["date_end"])
     freq = pd.Timedelta(CV.xrfreq_to_timedelta(facets["xrfreq"]))


### PR DESCRIPTION
Reverse logic to allow missing dates on FX data.

<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] HISTORY.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

In `_schema_dates` (which generates the "DATES" string), the fast-path for invariant data happend _before_ the optional checks. Invariant data should not have date_start and date_end, so the current code will always fail for `xrfreq='fx'`.

### Does this PR introduce a breaking change?
No.

### Other information:
