### PR TITLE
Fix the notebooks again

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,8 @@ build:
     pre_build:
       - sphinx-apidoc -o docs/apidoc --private --module-first xscen
       - env SKIP_NOTEBOOKS=1 sphinx-build -b linkcheck docs/ _build/linkcheck
+#    post_build:
+#      - rm -rf docs/notebooks/_data
 
 conda:
   environment: environment-dev.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,11 +79,11 @@ except TypeError:
 if skip_notebooks:
     warnings.warn("SKIP_NOTEBOOKS is set. Not executing notebooks.")
     nbsphinx_execute = "never"
-elif os.getenv("READTHEDOCS_VERSION_NAME") in ["latest", "stable"] or os.getenv(
-    "READTHEDOCS_VERSION_TYPE"
-) in ["tag"]:
-    if os.getenv("READTHEDOCS_OUTPUT") in ["pdf"]:
-        warnings.warn("Generating PDF version. Not executing notebooks.")
+elif (os.getenv("READTHEDOCS_VERSION_NAME") in ["latest", "stable"]) or (
+    os.getenv("READTHEDOCS_VERSION_TYPE") in ["tag"]
+):
+    if Path(__file__).parent.joinpath("notebooks/_data").exists():
+        warnings.warn("Notebook artefacts found. Not executing notebooks.")
         nbsphinx_execute = "never"
 
 # if skip_notebooks or os.getenv("READTHEDOCS_VERSION_TYPE") in [


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] HISTORY.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fixes the issue caused by running the notebooks twice by skipping the nbsphinx execution if `_data` is found
* Stages an alternative approach to fixing the bug, which involves deleting `_data` between stages and running the notebooks twice, for reference

### Does this PR introduce a breaking change?

No.

### Other information:
