### PR TITLE
Better DATES

### DIFF
--- a/xscen/catutils.py
+++ b/xscen/catutils.py
@@ -90,7 +90,10 @@ def _parse_level(text: str) -> str:
     return text
 
 
-@register_parse_type("datebounds", regex=r"(([\d]+(\-[\d]+)?)|fx)", group_count=3)
+# Minimum 4 digits for a date (a single year). Maximum is, in theory, YYYYMMDDHHMMSS so 14.
+@register_parse_type(
+    "datebounds", regex=r"(([\d]{4,15}(\-[\d]{4,15})?)|fx)", group_count=3
+)
 def _parse_datebounds(text: str) -> tuple[str, str]:
     """Parse helper to translate date bounds, used in the special DATES field."""
     if "-" in text:

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -107,7 +107,7 @@ def date_parser(
         except (KeyError, ValueError):
             try:
                 date = pd.Timestamp(date)
-            except pd._libs.tslibs.parsing.DateParseError:
+            except (pd._libs.tslibs.parsing.DateParseError, ValueError):
                 date = pd.NaT
     elif isinstance(date, cftime.datetime):
         for n in range(3):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] HISTORY.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Minimal pull request that fixes a bug I just had in the data catalogs.

The "DATES" format flag now needs at least 4 digits to match and a maximum of 15. I had removed that condition earlier, but I believe it was out of laziness to actually think about it. I see no way that a date would have fewer than 4 digits. I had some CORDEX files with a trailing ".1.nc" in the filename, and it shouldn't be recognized as date.

In `date_parser`, also catch `ValueError` when `pd.Timestamp` fails. I didn't know the object would raise that.


### Does this PR introduce a breaking change?
No.

### Other information:
