### PR TITLE
Better spatial mean

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added the ability to search for simulations that reach a given warming level. (:pull:`251`).
 * ``xs.spatial_mean`` now accepts the ``region="global"`` keyword to perform a global average (:issue:`94`, :pull:`260`).
+* ``xs.spatial_mean`` with ``method='xESMF'`` will also automatically segmentize polygons (down to a 1° resolution) to ensure a correct average (:pull:`260`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 v0.8.0 (unreleased)
 -------------------
-Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`).
+Contributors to this version: Gabriel Rondeau-Genesse (:user:`RondeauG`), Pascal Bourgault (:user:`aulemahal`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -13,6 +13,7 @@ Announcements
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added the ability to search for simulations that reach a given warming level. (:pull:`251`).
+* ``xs.spatial_mean`` now accepts the ``region="global"`` keyword to perform a global average (:issue:`94`, :pull:`260`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -34,6 +35,7 @@ Internal changes
 * Reduced the size of the files in /docs/notebooks/samples and changed the Notebooks and tests accordingly. (:issue:`247`, :pull:`248`).
 * Added a new `xscen.testing` module with the `datablock_3d` function previously located in `/tests/conftest.py`. (:pull:`248`).
 * New function `xscen.testing.fake_data` to generate fake data for testing. (:pull:`248`).
+* xESMF 0.8 Regridder and SpatialAverager argument ``out_chunks`` is now accepted by ``xs.regrid_dataset``  and ``xs.spatial_mean``. (:pull:`260`).
 
 v0.7.1 (2023-08-23)
 -------------------

--- a/xscen/aggregate.py
+++ b/xscen/aggregate.py
@@ -374,7 +374,7 @@ def spatial_mean(
     *,
     spatial_subset: bool = None,
     call_clisops: bool = False,
-    region: dict = None,
+    region: Union[dict, str] = None,
     kwargs: dict = None,
     simplify_tolerance: float = None,
     to_domain: str = None,
@@ -394,10 +394,11 @@ def spatial_mean(
     spatial_subset : bool
         If True, xscen.spatial.subset will be called prior to the other operations. This requires the 'region' argument.
         If None, this will automatically become True if 'region' is provided and the subsetting method is either 'cos-lat' or 'mean'.
-    region : dict
+    region : dict or str
         Description of the region and the subsetting method (required fields listed in the Notes).
         If method=='interp_centroid', this is used to find the region's centroid.
         If method=='xesmf', the bounding box or shapefile is given to SpatialAverager.
+        Can also be "global", for global averages. This is simply a shortcut for `{'name': 'global', 'method': 'bbox', 'lon_bnds' [-180, 180], 'lat_bnds': [-90, 90]}`.
     kwargs : dict
         Arguments to send to either mean(), interp() or SpatialAverager().
         For SpatialAverager, one can give `skipna` here, to be passed to the averager call itself.
@@ -450,6 +451,14 @@ def spatial_mean(
             category=FutureWarning,
         )
         spatial_subset = call_clisops
+
+    if region == "global":
+        region = {
+            "name": "global",
+            "method": "bbox",
+            "lon_bnds": [-180, 180],
+            "lat_bnds": [-90, 90],
+        }
 
     if (
         (region is not None)
@@ -587,26 +596,14 @@ def spatial_mean(
 
     # Uses xesmf.SpatialAverager
     elif method == "xesmf":
-        logger.warning(
-            "A bug has been found with xesmf.SpatialAverager that appears to impact big regions. "
-            "Until this is fixed, make sure that the computation is right or use multiple smaller regions."
-        )
         # If the region is a bounding box, call shapely and geopandas to transform it into an input compatible with xesmf
         if region["method"] == "bbox":
-            lon_point_list = [
+            polygon_geom = shapely.box(
                 region["lon_bnds"][0],
-                region["lon_bnds"][0],
-                region["lon_bnds"][1],
-                region["lon_bnds"][1],
-            ]
-            lat_point_list = [
                 region["lat_bnds"][0],
+                region["lon_bnds"][1],
                 region["lat_bnds"][1],
-                region["lat_bnds"][1],
-                region["lat_bnds"][0],
-            ]
-
-            polygon_geom = Polygon(zip(lon_point_list, lat_point_list))
+            )
             polygon = gpd.GeoDataFrame(index=[0], geometry=[polygon_geom])
 
             # Prepare the History field
@@ -619,8 +616,10 @@ def spatial_mean(
         elif region["method"] == "shape":
             if not isinstance(region["shape"], gpd.GeoDataFrame):
                 polygon = gpd.read_file(region["shape"])
+                name = Path(region["shape"]).name
             else:
                 polygon = region["shape"]
+                name = f"{len(polygon)} polygons"
 
             # Simplify the geometries to a given tolerance, if needed.
             # The simpler the polygons, the faster the averaging, but it will lose some precision.
@@ -632,7 +631,7 @@ def spatial_mean(
             # Prepare the History field
             new_history = (
                 f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] "
-                f"xesmf.SpatialAverager over {Path(region['shape']).name} - xESMF v{xe.__version__}"
+                f"xesmf.SpatialAverager over {name} - xESMF v{xe.__version__}"
             )
 
         else:
@@ -640,6 +639,9 @@ def spatial_mean(
 
         kwargs_copy = deepcopy(kwargs)
         skipna = kwargs_copy.pop("skipna", False)
+
+        # Pre-emptive segmentization. Same threshold as xESMF, but there's not strong analysis behind this choice
+        geoms = shapely.segmentize(polygon.geometry, 1)
 
         if (
             ds.cf["longitude"].ndim == 2
@@ -650,7 +652,7 @@ def spatial_mean(
 
             ds = ds.update(create_bounds_rotated_pole(ds))
 
-        savg = xe.SpatialAverager(ds, polygon.geometry, **kwargs_copy)
+        savg = xe.SpatialAverager(ds, geoms, **kwargs_copy)
         ds_agg = savg(ds, keep_attrs=True, skipna=skipna)
         extra_coords = {
             col: xr.DataArray(polygon[col], dims=("geom",))


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #94 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* One can now pass `region='global'` to `spatial_mean`. It will simply be replace by a bbox region covering the whole globe.
* `spatial_mean`, method `xesmf` will automatically segmentize the polygons down to a resolution of 1°, to ensure a correct average.
* Make `out_chunks` available in `regrid_dataset` and `spatial_mean` if using xesmf >= 0.8
* Fix `spatial_mean` with method `xesmf` and a `GeoDataFrame` as shape.

### Does this PR introduce a breaking change?
Shouldn't.

### Other information:
Added a test for  `region='global'`.
