### PR TITLE
Pin xarray for xclim compatibility

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,7 +26,8 @@ dependencies:
   - shapely >= 2
   - sparse
   - toolz
-  - xarray
+  # FIXME: Unpin xarray when xclim 0.46 is released
+  - xarray < 2023.09.0
   - xclim >=0.43.0
   - xesmf >=0.7
   - zarr


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] HISTORY.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Pins xarray to 2023.08 or earlier, so that the sdba notebook runs correctly. xclim 0.46 will solve that bug.

### Does this PR introduce a breaking change?
No

### Other information:
N.A.