### PR TITLE
Better resample

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ New features and enhancements
 * ``xs.spatial_mean`` now accepts the ``region="global"`` keyword to perform a global average (:issue:`94`, :pull:`260`).
 * ``xs.spatial_mean`` with ``method='xESMF'`` will also automatically segmentize polygons (down to a 1° resolution) to ensure a correct average (:pull:`260`).
 * Added documentation for `require_all_on` in `search_data_catalogs`. (:pull:`263`).
+* Better ``xs.extract.resample`` : support for weighted resampling operations when starting with frequencies coarser than daily and missing timesteps/values handling. (:issue:`80`, :issue:`93`, :pull:`265`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/goodtoknow.rst
+++ b/docs/goodtoknow.rst
@@ -37,12 +37,12 @@ There are many ways to open data in xscen workflows. The list below tries to mak
 Which function to use when resampling data
 ------------------------------------------
 
-:extract_dataset: :py:func:`~xscen.extract.extract_dataset` has resampling capabilities to provide daily data from finer sources.
+:extract_dataset: :py:func:`~xscen.extract.extract_dataset`'s resampling capabilities are meant to provide daily data from finer sources.
+
+:resample: :py:func`xscen.extract.resample` extends xarray's `resample` methods with support for weighted resampling when starting from data coarser than daily and for handling of missing timesteps or values.
 
 :xclim indicators: Through :py:func:`~xscen.indicators.compute_indicators`, xscen workflows can easily use `xclim indicators <https://xclim.readthedocs.io/en/stable/indicators.html>`_
-    to go from daily data to coarser (monthly, seasonal, annual).
-
-What is currently not covered by either `xscen` or `xclim` is a method to resample from data coarser than daily, where the base period is non-uniform (ex: resampling from monthly to annual data, taking into account the number of days per month).
+    to go from daily data to coarser (monthly, seasonal, annual), with missing values handling. This option will add more metadata than the two firsts.
 
 
 Metadata translation

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -428,9 +428,15 @@ class TestResample:
                 [1.49041096, 5.49041096, 9.49453552, 13.49041096, 17.49041096],
             ],
             ["MS", "std", "2YS", [6.92009239, 6.91557206]],
+            [
+                "QS",
+                "median",
+                "YS",
+                [1.516437, 5.516437, 9.516437, 13.51092864, 17.516437],
+            ],
         ],
     )
-    def test_mean_from_monthly(self, infrq, meth, outfrq, exp):
+    def test_weighted(self, infrq, meth, outfrq, exp):
         da = timeseries(
             np.arange(48),
             variable="tas",
@@ -440,7 +446,7 @@ class TestResample:
         out = xs.extract.resample(da, outfrq, method=meth)
         np.testing.assert_allclose(out.isel(time=slice(0, 5)), exp)
 
-    def test_wind_from_monthly(self):
+    def test_weighted_wind(self):
         uas = timeseries(
             np.arange(48),
             variable="uas",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from conftest import notebooks
 from xclim.testing.helpers import test_timeseries as timeseries
 
@@ -413,3 +414,77 @@ class TestSubsetWarmingLevel:
 
     def test_none(self):
         assert xs.subset_warming_level(TestSubsetWarmingLevel.ds, wl=20) is None
+
+
+class TestResample:
+    @pytest.mark.parametrize(
+        "infrq,meth,outfrq,exp",
+        [
+            ["MS", "mean", "QS-DEC", [0.47457627, 3, 6.01086957, 9, 11.96666667]],
+            [
+                "QS-DEC",
+                "mean",
+                "YS",
+                [1.49041096, 5.49041096, 9.49453552, 13.49041096, 17.49041096],
+            ],
+            ["MS", "std", "2YS", [6.92009239, 6.91557206]],
+        ],
+    )
+    def test_mean_from_monthly(self, infrq, meth, outfrq, exp):
+        da = timeseries(
+            np.arange(48),
+            variable="tas",
+            start="2001-01-01",
+            freq=infrq,
+        )
+        out = xs.extract.resample(da, outfrq, method=meth)
+        np.testing.assert_allclose(out.isel(time=slice(0, 5)), exp)
+
+    def test_wind_from_monthly(self):
+        uas = timeseries(
+            np.arange(48),
+            variable="uas",
+            start="2001-01-01",
+            freq="MS",
+        )
+        vas = timeseries(
+            np.arange(48),
+            variable="vas",
+            start="2001-01-01",
+            freq="MS",
+        )
+        ds = xr.merge([uas, vas])
+        out = xs.extract.resample(ds.uas, "YS", method="wind_direction", ds=ds)
+        np.testing.assert_allclose(out, [5.5260274, 17.5260274, 29.5260274, 41.5136612])
+
+    def test_missing(self):
+        da = timeseries(
+            np.arange(48),
+            variable="tas",
+            start="2001-01-01",
+            freq="MS",
+        )
+        out = xs.extract.resample(da, "QS-DEC", method="mean", missing="drop")
+        assert out.size == 15
+
+        out = xs.extract.resample(da, "QS-DEC", method="mean", missing="mask")
+        assert out.isel(time=0).isnull().all()
+
+    def test_missing_xclim(self):
+        arr = np.arange(48).astype(float)
+        arr[0] = np.nan
+        arr[40:] = np.nan
+        da = timeseries(
+            arr,
+            variable="tas",
+            start="2001-01-01",
+            freq="MS",
+        )
+        out = xs.extract.resample(da, "YS", method="mean", missing={"method": "any"})
+        assert out.isel(time=0).isnull().all()
+
+        out = xs.extract.resample(
+            da, "YS", method="mean", missing={"method": "pct", "tolerance": 0.6}
+        )
+        assert out.isel(time=0).notnull().all()
+        assert out.isel(time=-1).isnull().all()

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -389,8 +389,8 @@ def resample(
         using the mapping in CVs/resampling_methods.json. If the variable is not found there,
         "mean" is used by default.
     missing: {'mask', 'drop'} or dict, optional
-        If 'mask' or 'drop', target periods with fewer steps than expected are masked or dropped.
-        For example, for daily data beginning in January with a `target_frequency` of "QS-DEC". the first season is missing one month.
+        If 'mask' or 'drop', target periods that would have been computed from fewer timesteps than expected are masked or dropped, using a threshold of 5% of missing data.
+        For example, the first season of a `target_frequency` of "QS-DEC" will be masked or dropped if data only starts in January.
         If a dict, it points to a xclim check missing method which will mask periods according to their number of NaN values.
         The dict must contain a "method" field corresponding to the xclim method name and may contain
         any other args to pass. Options are documented in :py:mod:`xclim.core.missing`.

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -1274,3 +1274,9 @@ def season_sort_key(idx: pd.Index, name: str = None):
         # TypeError if season element was not a string.
         pass
     return idx
+
+
+def xrfreq_to_timedelta(freq):
+    """Approximate the length of a period based on its frequency offset."""
+    N, B, _, _ = parse_offset(freq)
+    return N * pd.Timedelta(CV.xrfreq_to_timedelta(B, "NaT"))


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #80 and fixes #93.
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
- Extends `resample` to explicitly cover the case where the `initial_frequency` is coarser than "W", meaning that it has a non-uniform length.
    + Weights are the proportion of days of the total period contributed by each timesteps. Ex: MS to YS => weight = daysinmonth / 365 .
    + "weighted resample" is activated for methods : "wind_direction", "mean", "std", "var" and "median". Those are the methods from `DataArray.resample` for which a weighted version makes sense.
    + Implemented a generic version that uses `resample(...).map(....weighted().op()) `, with a special case for "median" since that's not a `weighted` op. Mapping a function is less performant, especially since flox can't be used.
    + Implemented a shortcut for `method='mean'` that simplifies to a simple `resample().sum()`, meaning it should be much more performant and able to use `flox`. Without dask and on the air dataset, I had a 3x speedup.

- Extends `resample` to handle missing values with new `missing` arg:
    + `mask` : Mask incomplete periods (as in missing timesteps)
    + `drop`: Drop incomplete periods (same)
    + dict with `method=<xclim missing method>`  : Mask periods failing specified xclim missing check.

### Does this PR introduce a breaking change?
No.

### Other information:

