### PR TITLE
Better save_to_zarr

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ New features and enhancements
 * ``xs.spatial_mean`` with ``method='xESMF'`` will also automatically segmentize polygons (down to a 1° resolution) to ensure a correct average (:pull:`260`).
 * Added documentation for `require_all_on` in `search_data_catalogs`. (:pull:`263`).
 * ``xs.save_to_table`` and ``xs.io.to_table`` to transform datasets and arrays to DataFrames, but with support for multi-columns, multi-sheets and localized table of content generation.
+* ``xs.io.round_bits`` to round floating point variable up to a number of bits, allowing for a better compression. This can be combined with the saving step through argument "bitround" of ``save_to_netcdf`` and ``save_to_zarr``. (:pull:`266`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -130,7 +130,10 @@ def test_round_bits(datablock_3d):
     dar = xs.io.round_bits(da, 12)
     # Close but NOT equal, meaning something happened
     np.testing.assert_allclose(da, dar, rtol=0.013)
-    assert not (da == dar).any()
+    # There's always a chance of having a randomly chosen number with only zeros in the bit rounded part of the mantissa
+    # Assuming a uniform distribution of binary numbers (which it is not), the chance of this happening should be:
+    # 2^(23 - 12 + 1) / 2^24 = 2^(-12) ~ 0.02 % (but we'll allow 1% of values to be safe)
+    assert (da != dar).sum() > (0.99 * da.size)
 
 
 class TestSaveToZarr:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -151,6 +151,6 @@ class TestSaveToZarr:
     def test_guess_bitround(self, vname, vtype, bitr, exp):
         if exp == "error":
             with pytest.raises(ValueError):
-                xs.io._guess_keepbits(bitr, vname, vtype)
+                xs.io._get_keepbits(bitr, vname, vtype)
         else:
-            assert xs.io._guess_keepbits(bitr, vname, vtype) == exp
+            assert xs.io._get_keepbits(bitr, vname, vtype) == exp

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,5 +1,3 @@
-import shutil as sh
-
 import numpy as np
 from conftest import notebooks
 from xclim.testing.helpers import test_timeseries as timeseries

--- a/xscen/io.py
+++ b/xscen/io.py
@@ -326,7 +326,7 @@ def _guess_keepbits(bitround, varname, vartype):
     if not np.issubdtype(vartype, np.floating) or bitround is False:
         if isinstance(bitround, dict) and varname in bitround:
             raise ValueError(
-                f"A keepbits value was given for variable {varname} even though it is not of a floatig dtype."
+                f"A keepbits value was given for variable {varname} even though it is not of a floating dtype."
             )
         return None
     if bitround is True:
@@ -365,7 +365,7 @@ def save_to_netcdf(
       If not False, float variables are bit-rounded by dropping a certain number of bits from their mantissa, allowing for a much better compression.
       If an int, this is the number of bits to keep for all float variables.
       If a dict, a mapping from variable name to the number of bits to keep.
-      If True, the number of bits to keep is guessed based on the variable's name, defaulting to 12, which yields a relative error of 0.012%.
+      If True, the number of bits to keep is guessed based on the variable's name, defaulting to 12, which yields a relative error below 0.013%.
     compute : bool
         Whether to start the computation or return a delayed object.
     netcdf_kwargs : dict, optional

--- a/xscen/io.py
+++ b/xscen/io.py
@@ -321,7 +321,7 @@ def round_bits(da: xr.DataArray, keepbits: int):
     return da
 
 
-def _guess_keepbits(bitround, varname, vartype):
+def _get_keepbits(bitround, varname, vartype):
     # Guess the number of bits to keep depending on how bitround was passed, the var dtype and the var name.
     if not np.issubdtype(vartype, np.floating) or bitround is False:
         if isinstance(bitround, dict) and varname in bitround:
@@ -391,7 +391,7 @@ def save_to_netcdf(
     netcdf_kwargs.setdefault("format", "NETCDF4")
 
     for var in list(ds.data_vars.keys()):
-        if keepbits := _guess_keepbits(bitround, var, ds[var].dtype):
+        if keepbits := _get_keepbits(bitround, var, ds[var].dtype):
             ds = ds.assign({var: round_bits(ds[var], keepbits)})
 
     _coerce_attrs(ds.attrs)
@@ -507,7 +507,7 @@ def save_to_zarr(
             ds = ds.drop_vars(var)
             if encoding:
                 encoding.pop(var)
-        if keepbits := _guess_keepbits(bitround, var, ds[var].dtype):
+        if keepbits := _get_keepbits(bitround, var, ds[var].dtype):
             ds = ds.assign({var: round_bits(ds[var], keepbits)})
 
     if len(ds.data_vars) == 0:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* New func ``xs.io.round_bits`` to round a floating point variable up to a number of bits, allowing for a much better compression afterwards.
* New "bitround" arg to `save_to_zarr`  and `save_to_netcdf`, allowing to combine the bit rounding and the saving. The argument can take many forms for more flexibility. 


### Does this PR introduce a breaking change?
No.


### Other information:
Default keepbits value is guessed from the variable name, with a default of 12 (0.0122% of rel error). Better guesses should be given in `xs.io.KEEPBITS`, but I have none for now.