### PR TITLE
Better get_warming_level

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed a bug in ``xs.search_data_catalogs`` when searching for fixed fields and specific experiments/members. (:pull:`251`).
 * Fixed a bug in the documentation build configuration that prevented stable/latest and tagged documentation builds from resolving on ReadTheDocs. (:pull:`256`).
+* Fixed ``get_warming_level`` to avoid incomplete matches. (:pull:`269`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -929,13 +929,13 @@ def get_warming_level(
     out = {}
     for model in info_models:
         # choose colum based in ds cat attrs
-        mip = models.mip_era.str.match(model["mip_era"])
-        src = models.source.str.match(model["source"])
+        mip = models.mip_era.str.fullmatch(model["mip_era"])
+        src = models.source.str.fullmatch(model["source"])
         if not src.any():
             # Maybe it's an RCM, then source may contain the institute
             src = models.source.apply(lambda s: model["source"].endswith(s))
-        exp = models.experiment.str.match(model["experiment"])
-        mem = models.member.str.match(model["member"])
+        exp = models.experiment.str.fullmatch(model["experiment"])
+        mem = models.member.str.fullmatch(model["member"])
 
         candidates = models[mip & src & exp & mem]
         if candidates.empty:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

In #215, I used `pd.Series.str.match` to find models in the global tas dataset. However, `match` will return a match even if only the beginning of the string matches the pattern.

For example: looking for "EC-Earth3" would match for "EC-Earth3-CC". This resulted in some models getting multiple matches even though an _exact_ match existed.

This PR switches to `fullmatch` which ensures the full string matches, which I'm pretty sure is the expected behaviour when regex is not used. If needed, the previous behaviour can be obtained by adding ".*" to the query (like "EC-Earth3.*").

### Does this PR introduce a breaking change?
Yes and no. I think the new behaviour is the proper one.