### PR TITLE
More intuitive exclusions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,7 @@ Bug fixes
 * Fixed a bug in ``xs.search_data_catalogs`` when searching for fixed fields and specific experiments/members. (:pull:`251`).
 * Fixed a bug in the documentation build configuration that prevented stable/latest and tagged documentation builds from resolving on ReadTheDocs. (:pull:`256`).
 * Fixed ``get_warming_level`` to avoid incomplete matches. (:pull:`269`).
+* `search_data_catalogs` now eliminates anything that matches any entry in `exclusions`. (:issue:`275`, :pull:`280`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -28,9 +28,11 @@ class TestSearchDataCatalogs:
             other_search_criteria={"experiment": ["ssp585"]}
             if other_arg == "other"
             else None,
-            exclusions={"member": "r2.*"} if other_arg == "exclusion" else None,
+            exclusions={"member": "r2.*", "domain": ["gr2"]}
+            if other_arg == "exclusion"
+            else None,
         )
-        assert len(out) == 13 if other_arg is None else 2 if other_arg == "other" else 6
+        assert len(out) == 13 if other_arg is None else 2 if other_arg == "other" else 4
 
     @pytest.mark.parametrize(
         "periods, coverage_kwargs",


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #275
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] HISTORY.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `search_data_catalogs` now loops through the provided keys, so that it actually eliminates anything that matches.

### Does this PR introduce a breaking change?

- No. The behaviour of `exclusions` will change, but this is a bugfix more than anything.

### Other information:
