### PR TITLE
Support robustness functions in `xs.ensemble_stats`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ New features and enhancements
 * Better ``xs.extract.resample`` : support for weighted resampling operations when starting with frequencies coarser than daily and missing timesteps/values handling. (:issue:`80`, :issue:`93`, :pull:`265`).
 * New argument ``attribute_weights`` to ``generate_weights`` to allow for custom weights. (:pull:`252`).
 * ``xs.io.round_bits`` to round floating point variable up to a number of bits, allowing for a better compression. This can be combined with the saving step through argument ``"bitround"`` of ``save_to_netcdf`` and ``save_to_zarr``. (:pull:`266`).
+* Added the ability to directly provide an ensemble dataset to ``xs.ensemble_stats``. (:pull:`299`).
+* Added support in ``xs.ensemble_stats`` for the new robustness-related functions available in `xclim`. (:pull:`299`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xscen/ensembles.py
+++ b/xscen/ensembles.py
@@ -150,6 +150,10 @@ def ensemble_stats(  # noqa: C901
             # FIXME: This can be removed once change_significance is removed.
             #  It's here because the 'ref' default was removed for change_significance in xclim 0.47.
             stats_kwargs.setdefault("ref", None)
+            if (stats_kwargs.get("ref") is not None) and len(statistics.keys()) > 1:
+                raise ValueError(
+                    f"The input requirements for '{stat}' when 'ref' is specified are not compatible with other statistics."
+                )
 
             # These statistics only work on DataArrays
             for v in ens.data_vars:

--- a/xscen/ensembles.py
+++ b/xscen/ensembles.py
@@ -50,7 +50,7 @@ def ensemble_stats(  # noqa: C901
         xclim.ensembles statistics to be called. Dictionary in the format {function: arguments}.
         If a function requires 'weights', you can leave it out of this dictionary and
         it will be applied automatically if the 'weights' argument is provided.
-        See the Notes section for more details on robustness statistics, which require additional arguments.
+        See the Notes section for more details on robustness statistics, which are more complex in their usage.
     create_kwargs : dict, optional
         Dictionary of arguments for xclim.ensembles.create_ensemble.
     weights : xr.DataArray, optional
@@ -79,6 +79,13 @@ def ensemble_stats(  # noqa: C901
          In this case, all outputs will be returned.
       2. Having 'robustness_fractions' as a nested dictionary under 'robustness_categories'.
          In this case, only the robustness categories will be returned.
+
+    * A 'ref' DataArray can be passed to 'change_significance' and 'robustness_fractions', which will be used by xclim to compute deltas
+      and perform some significance tests. However, this supposes that both 'datasets' and 'ref' are still timeseries (e.g. annual means),
+      not climatologies where the 'time' dimension represents the period over which the climatology was computed. Thus,
+      using 'ref' is only accepted if 'robustness_fractions' (or 'robustness_categories') is the only statistic being computed.
+    * If you want to use compute a robustness statistic on a climatology, you should first compute the climatologies and deltas yourself,
+      then leave 'ref' as None and pass the deltas as the 'datasets' argument. This will be compatible with other statistics.
 
     See Also
     --------
@@ -150,7 +157,7 @@ def ensemble_stats(  # noqa: C901
             # FIXME: This can be removed once change_significance is removed.
             #  It's here because the 'ref' default was removed for change_significance in xclim 0.47.
             stats_kwargs.setdefault("ref", None)
-            if (stats_kwargs.get("ref") is not None) and len(statistics.keys()) > 1:
+            if (stats_kwargs.get("ref") is not None) and len(statistics_to_compute) > 1:
                 raise ValueError(
                     f"The input requirements for '{stat}' when 'ref' is specified are not compatible with other statistics."
                 )

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -1011,7 +1011,7 @@ def publish_release_notes(
             changes = re.sub(search, replacement, changes)
 
     if not file:
-        return
+        return changes
     if isinstance(file, (Path, os.PathLike)):
         file = Path(file).open("w")
     print(changes, file=file)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - No.
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* You can now directly provide an ensemble dataset to `xs.ensemble_stats`.
* `xs.ensemble_stats` now supports the robustness-related functions from `xclim`.
* Small bugfix in `publish_release_notes`

### Does this PR introduce a breaking change?

* Removed explicit support for `ref` as it was implemented, since it actually was completely broken... See #298. 

### Other information:
