### PR TITLE
Allow for fixture creation to be skipped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Internal changes
     * The OpenSSF `scorecard.yml` workflow has been added to the GitHub workflows to evaluate package security.
     * Code formatting tools (`black`, `blackdoc`, `isort`) are now hard-pinned. These need to be kept in sync with changes from `pre-commit`. (Dependabot should perform this task automatically.)
     * The versioning system has been updated to follow the Semantic Versioning 2.0.0 standard.
+* Fixed an issue with `pytest -m "not requires_netcdf"` not working as expected. (:pull:`345`).
 
 v0.8.0 (2024-01-16)
 -------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,13 @@ def cleanup_notebook_data_folder(request):
     request.addfinalizer(remove_data_folder)
 
 
-@pytest.mark.requires_netcdf
 @pytest.fixture(scope="session")
-def samplecat():
+def samplecat(request):
     """Generate a sample catalog with the tutorial netCDFs."""
+    mark_skip = request.config.getoption("-m")
+    if "not requires_netcdf" == mark_skip:
+        pytest.skip("Skipping tests that require netCDF files")
+
     df = xs.parse_directory(
         directories=[SAMPLES_DIR],
         patterns=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,9 @@ def cleanup_notebook_data_folder(request):
 def samplecat(request):
     """Generate a sample catalog with the tutorial netCDFs."""
     mark_skip = request.config.getoption("-m")
-    if "not requires_netcdf" == mark_skip or not SAMPLES_DIR.exists():
+    if "not requires_netcdf" in mark_skip or not SAMPLES_DIR.exists():
         pytest.skip("Skipping tests that require netCDF files")
-    elif list(SAMPLES_DIR.rglob("*.nc")) is []:
+    elif not list(SAMPLES_DIR.rglob("*.nc")):
         pytest.skip("No netCDF files found in the tutorial samples folder")
 
     df = xs.parse_directory(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,10 @@ def cleanup_notebook_data_folder(request):
 def samplecat(request):
     """Generate a sample catalog with the tutorial netCDFs."""
     mark_skip = request.config.getoption("-m")
-    if "not requires_netcdf" == mark_skip:
+    if "not requires_netcdf" == mark_skip or not SAMPLES_DIR.exists():
         pytest.skip("Skipping tests that require netCDF files")
+    elif list(SAMPLES_DIR.rglob("*.nc")) is []:
+        pytest.skip("No netCDF files found in the tutorial samples folder")
 
     df = xs.parse_directory(
         directories=[SAMPLES_DIR],


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #344 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* adds a check to not bother creating a particular fixture if the `-m "not requires_netcdf"` flag is set or if the files are missing. 

### Does this PR introduce a breaking change?

No.

### Other information:

`pytest.mark` doesn't work for `pytest.fixture` objects. TIL