### PR TITLE
Fix wl_bounds and unstack_dates

### DIFF
--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -1107,7 +1107,7 @@ def get_warming_level(  # noqa: C901
     if isinstance(realization, xr.DataArray):
         if return_horizon:
             return xr.DataArray(
-                out, dims=(realization.dims[0], "bounds"), coords=realization.coords
+                out, dims=(realization.dims[0], "wl_bounds"), coords=realization.coords
             )
         return xr.DataArray(out, dims=(realization.dims[0],), coords=realization.coords)
 
@@ -1251,7 +1251,7 @@ def subset_warming_level(
                 data.expand_dims(warminglevel=wl_crd).assign_coords(
                     time=fake_time[: data.time.size],
                     warminglevel_bounds=(
-                        ("realization", "warminglevel", "bounds"),
+                        ("realization", "warminglevel", "wl_bounds"),
                         [[bnds_crd]],
                     ),
                 )
@@ -1271,10 +1271,10 @@ def subset_warming_level(
             # WL not reached or not completely inside ds time
             if start_yr is None or ds_wl.time.size == 0:
                 ds_wl = ds.isel(time=slice(0, fake_time.size)) * np.NaN
-                wlbnds = (("warminglevel", "bounds"), [[np.NaN, np.NaN]])
+                wlbnds = (("warminglevel", "wl_bounds"), [[np.NaN, np.NaN]])
             else:
                 wlbnds = (
-                    ("warminglevel", "bounds"),
+                    ("warminglevel", "wl_bounds"),
                     [
                         [
                             date_cls(int(start_yr), 1, 1),

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -1082,7 +1082,7 @@ def unstack_dates(
         )
 
     # Fast track for annual
-    if base == "A":
+    if base in "YA":
         if seasons:
             seaname = seasons[first.month]
         elif anchor == "JAN":


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fix `unstack_dates` where a "A" freq base was still to be found.
* Fix `get_warming_levels` when used with a dataset that already has bounds (like for the grid). The `warminglevel_bounds` variable now has the dimension "wl_bounds" instead of "bounds" to avoid name conflicts.

### Does this PR introduce a breaking change?
No. Unless someone was using the `bounds` dimension ?

### Other information:
