### PR TITLE
Use sdba options for xclim by default

### DIFF
--- a/docs/notebooks/2_getting_started.ipynb
+++ b/docs/notebooks/2_getting_started.ipynb
@@ -36,7 +36,12 @@
    "source": [
     "from pathlib import Path\n",
     "\n",
+    "# A temporary bug fix waiting for xclim 0.49\n",
+    "import xclim as xc\n",
+    "\n",
     "import xscen as xs\n",
+    "\n",
+    "xc.set_options(sdba_encode_cf=False)\n",
     "\n",
     "# Folder where to put the data\n",
     "output_folder = Path().absolute() / \"_data\"\n",

--- a/xscen/biasadjust.py
+++ b/xscen/biasadjust.py
@@ -15,6 +15,7 @@ from .config import parse_config
 from .utils import minimum_calendar, standardize_periods
 
 logger = logging.getLogger(__name__)
+xc.set_options(sdba_encode_cf=True, sdba_extra_output=False)
 
 
 __all__ = [
@@ -287,9 +288,8 @@ def adjust(
             kwargs.setdefault("kind", ADJ.kind)
             xclim_adjust_args["detrend"] = getattr(sdba.detrending, name)(**kwargs)
 
-        with xc.set_options(sdba_encode_cf=True, sdba_extra_output=False):
-            out = ADJ.adjust(sim_sel, **xclim_adjust_args)
-            slices.extend([out])
+        out = ADJ.adjust(sim_sel, **xclim_adjust_args)
+        slices.extend([out])
     # put all the adjusted period back together
     dscen = xr.concat(slices, dim="time")
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
Instead of setting the options only when calling xclim's `adjust`, we set the options globally at import time. 

This fixes the subtle issue noted in Ouranosinc/xclim#1674 : the context options are not seen by all code when dask-backed data is used. as the actual computation occurs outside of the context.

It also allows to change these options at run time. `xc.set_options(sdba_encode_cf=False)` will fix #362, for example. This was not possible earlier as the option context was within the function and couldn't be modified by the user.

### Does this PR introduce a breaking change?
Yes, issue #362  will now occur on dask arrays too, until xclim's PR is merged. But it can be circumvented as shown above.