### PR TITLE
Add biasadjust tests

### DIFF
--- a/docs/notebooks/2_getting_started.ipynb
+++ b/docs/notebooks/2_getting_started.ipynb
@@ -36,7 +36,12 @@
    "source": [
     "from pathlib import Path\n",
     "\n",
+    "# A temporary bug fix waiting for xclim 0.49\n",
+    "import xclim as xc\n",
+    "\n",
     "import xscen as xs\n",
+    "\n",
+    "xc.set_options(sdba_encode_cf=False)\n",
     "\n",
     "# Folder where to put the data\n",
     "output_folder = Path().absolute() / \"_data\"\n",

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -1,0 +1,354 @@
+import dask
+import numpy as np
+import pytest
+import xarray as xr
+import xclim as xc
+from conftest import notebooks
+from xclim.testing.helpers import test_timeseries as timeseries
+
+import xscen as xs
+
+xc.set_options(
+    sdba_encode_cf=False
+)  # FIXME: A temporary bug fix waiting for xclim 0.49
+
+try:
+    import xesmf as xe
+except ImportError:
+    xe = None
+
+
+class TestTrain:
+    dref = timeseries(
+        np.ones(365 * 3), variable="tas", start="2001-01-01", freq="D", as_dataset=True
+    )
+
+    dhist = timeseries(
+        np.concatenate([np.ones(365 * 2) * 2, np.ones(365) * 3]),
+        variable="tas",
+        start="2001-01-01",
+        freq="D",
+        as_dataset=True,
+    )
+    dhist.attrs["cat:xrfreq"] = "D"
+    dhist.attrs["cat:domain"] = "one_point"
+    dhist.attrs["cat:id"] = "fake_id"
+
+    @pytest.mark.parametrize(
+        "var, period",
+        [("tas", ["2001", "2002"]), (["tas"], ["2003", "2003"])],
+    )
+    def test_basic_train(self, var, period):
+        out = xs.train(self.dref, self.dhist, var=var, period=period)
+
+        assert out.attrs["cat:xrfreq"] == "D"
+        assert out.attrs["cat:domain"] == "one_point"
+        assert out.attrs["cat:id"] == "fake_id"
+        assert out.attrs["cat:processing_level"] == "training_tas"
+
+        assert "dayofyear" in out
+        assert "quantiles" in out
+        result = [-1] * 365 if period == ["2001", "2002"] else [-2] * 365
+        np.testing.assert_array_equal(out["scaling"], result)
+
+    def test_preprocess(self):
+
+        dref360 = xc.core.calendar.convert_calendar(
+            self.dref, "360_day", align_on="year"
+        )
+
+        out = xs.train(
+            dref360,
+            self.dhist,
+            var="tas",
+            period=["2001", "2002"],
+            adapt_freq={"thresh": "2 K"},
+            jitter_over={"upper_bnd": "3 K", "thresh": "2 K"},
+            jitter_under={"thresh": "2 K"},
+        )
+
+        assert out.attrs["train_params"] == {
+            "maximal_calendar": "noleap",
+            "adapt_freq": {"thresh": "2 K"},
+            "jitter_over": {"upper_bnd": "3 K", "thresh": "2 K"},
+            "jitter_under": {"thresh": "2 K"},
+            "var": ["tas"],
+        }
+
+        assert "pth" in out
+        assert "dP0" in out
+        assert "dayofyear" in out
+        assert "quantiles" in out
+
+    def test_group(self):
+        out = xs.train(
+            self.dref,
+            self.dhist,
+            var="tas",
+            period=["2001", "2002"],
+            group={"group": "time.month", "window": 1},
+        )
+
+        out1 = xs.train(
+            self.dref,
+            self.dhist,
+            var="tas",
+            period=["2001", "2002"],
+            group="time.month",
+        )
+
+        assert "month" in out
+        assert "quantiles" in out
+        assert out1.equals(out)
+
+    def test_errors(self):
+        with pytest.raises(ValueError):
+            xs.train(self.dref, self.dhist, var=["tas", "pr"], period=["2001", "2002"])
+
+
+class TestAdjust:
+    dref = timeseries(
+        dask.array.from_array(
+            np.ones(365 * 3)
+        ),  # dask array b/c xclim bug with sdba_encode_cf
+        variable="tas",
+        start="2001-01-01",
+        freq="D",
+        as_dataset=True,
+    )
+
+    dsim = timeseries(
+        np.concatenate([np.ones(365 * 3) * 2, np.ones(365 * 3) * 4]),
+        variable="tas",
+        start="2001-01-01",
+        freq="D",
+        as_dataset=True,
+    )
+    dsim.attrs["cat:xrfreq"] = "D"
+    dsim.attrs["cat:domain"] = "one_point"
+    dsim.attrs["cat:id"] = "fake_id"
+
+    @pytest.mark.parametrize(
+        "periods, to_level, bias_adjust_institution, bias_adjust_project",
+        [
+            (["2001", "2006"], None, None, None),
+            ([["2001", "2001"], ["2006", "2006"]], "test", "i", "p"),
+        ],
+    )
+    def test_basic(
+        self, periods, to_level, bias_adjust_institution, bias_adjust_project
+    ):
+        dtrain = xs.train(
+            self.dref,
+            self.dsim.sel(time=slice("2001", "2003")),
+            var="tas",
+            period=["2001", "2003"],
+        )
+
+        out = xs.adjust(
+            dtrain,
+            self.dsim,
+            periods=periods,
+            to_level=to_level,
+            # xclim_adjust_args={'detrend': {
+            #     'LoessDetrend': {'f': 0.2, 'niter': 1, 'd': 0,
+            #                      'weights': 'tricube'}}},
+            bias_adjust_institution=bias_adjust_institution,
+            bias_adjust_project=bias_adjust_project,
+            # moving_yearly_window={'window': 2, 'step': 1},
+        )
+        assert out.attrs["cat:processing_level"] == to_level or "biasadjusted"
+        assert out.attrs["cat:variable"] == ("tas",)
+        assert xc.core.calendar.get_calendar(out) == "noleap"
+
+        if bias_adjust_institution is not None:
+            assert out.attrs["cat:bias_adjust_institution"] == "i"
+        if bias_adjust_project is not None:
+            assert out.attrs["cat:bias_adjust_project"] == "p"
+
+        assert out.time.dt.year.values[0] == 2001
+        assert out.time.dt.year.values[-1] == 2006
+
+        if periods == ["2001", "2006"]:
+            np.testing.assert_array_equal(
+                out["tas"].values,
+                np.concatenate([np.ones(365 * 3) * 1, np.ones(365 * 3) * 3]),
+            )
+        else:  # periods==[['2001','2001'], ['2006','2006']]
+            np.testing.assert_array_equal(
+                out["tas"].values,
+                np.concatenate([np.ones(365 * 1) * 1, np.ones(365 * 1) * 3]),
+            )
+
+    def test_write_train(self):
+        dtrain = xs.train(
+            self.dref,
+            self.dsim.sel(time=slice("2001", "2003")),
+            var="tas",
+            period=["2001", "2003"],
+            adapt_freq={"thresh": "2 K"},
+            jitter_over={"upper_bnd": "3 K", "thresh": "2 K"},
+            jitter_under={"thresh": "2 K"},
+        )
+
+        root = str(notebooks / "_data")
+        xs.save_to_zarr(dtrain, f"{root}/test.zarr", mode="o")
+        dtrain2 = xr.open_dataset(
+            f"{root}/test.zarr", chunks={"dayofyear": 365, "quantiles": 15}
+        )
+
+        out = xs.adjust(
+            dtrain,
+            self.dsim,
+            periods=["2001", "2006"],
+            xclim_adjust_args={
+                "detrend": {
+                    "LoessDetrend": {"f": 0.2, "niter": 1, "d": 0, "weights": "tricube"}
+                }
+            },
+        )
+
+        out2 = xs.adjust(
+            dtrain2,
+            self.dsim,
+            periods=["2001", "2006"],
+            xclim_adjust_args={
+                "detrend": {
+                    "LoessDetrend": {"f": 0.2, "niter": 1, "d": 0, "weights": "tricube"}
+                }
+            },
+        )
+
+        assert (
+            out.tas.attrs["bias_adjustment"]
+            == "DetrendedQuantileMapping(group=Grouper(name='time.dayofyear',"
+            " window=31), kind='+').adjust(sim, detrend=<LoessDetrend>),"
+            " ref and hist were prepared with jitter_under_thresh(ref, hist,"
+            " {'thresh': '2 K'}) and jitter_over_thresh(ref, hist, {'upper_bnd':"
+            " '3 K', 'thresh': '2 K'}) and adapt_freq(ref, hist, {'thresh': '2 K'})"
+        )
+
+        assert (
+            out2.tas.attrs["bias_adjustment"]
+            == "DetrendedQuantileMapping(group=Grouper(name='time.dayofyear',"
+            " window=31), kind='+').adjust(sim, detrend=<LoessDetrend>), ref and"
+            " hist were prepared with jitter_under_thresh(ref, hist, {'thresh':"
+            " '2 K'}) and jitter_over_thresh(ref, hist, {'upper_bnd': '3 K',"
+            " 'thresh': '2 K'}) and adapt_freq(ref, hist, {'thresh': '2 K'})"
+        )
+
+        assert out.equals(out2)
+
+    def test_xclim_vs_xscen(
+        self,
+    ):  # should give the same results  using xscen and xclim
+
+        dref = (
+            timeseries(
+                dask.array.from_array(
+                    np.random.randint(0, high=10, size=(365 * 3) + 1)
+                ),
+                variable="pr",
+                start="2001-01-01",
+                freq="D",
+                as_dataset=True,
+            )
+            .astype("float32")
+            .chunk({"time": -1})
+        )
+
+        dsim = (
+            timeseries(
+                np.random.randint(0, high=10, size=365 * 6 + 1),
+                variable="pr",
+                start="2001-01-01",
+                freq="D",
+                as_dataset=True,
+            )
+            .astype("float32")
+            .chunk({"time": -1})
+        )
+        dhist = dsim.sel(time=slice("2001", "2003")).chunk({"time": -1})
+
+        # xscen version
+        dtrain_xscen = xs.train(
+            dref,
+            dhist,
+            var="pr",
+            period=["2001", "2003"],
+            adapt_freq={"thresh": "1 mm d-1"},
+            jitter_under={"thresh": "0.01 mm d-1"},
+            xclim_train_args={"kind": "*", "nquantiles": 50},
+        )
+
+        out_xscen = xs.adjust(
+            dtrain_xscen,
+            dsim,
+            periods=["2001", "2006"],
+            xclim_adjust_args={
+                "detrend": {
+                    "LoessDetrend": {"f": 0.2, "niter": 1, "d": 0, "weights": "tricube"}
+                },
+                "interp": "nearest",
+                "extrapolation": "constant",
+            },
+        )
+
+        # xclim version
+        with xc.set_options(sdba_extra_output=True):
+            group = xc.sdba.Grouper(group="time.dayofyear", window=31)
+
+            drefx = xc.core.calendar.convert_calendar(
+                dref.sel(time=slice("2001", "2003")), "noleap"
+            )
+            dhistx = xc.core.calendar.convert_calendar(
+                dhist.sel(time=slice("2001", "2003")), "noleap"
+            )
+            dsimx = xc.core.calendar.convert_calendar(
+                dsim.sel(time=slice("2001", "2006")), "noleap"
+            )
+
+            drefx["pr"] = xc.sdba.processing.jitter_under_thresh(
+                drefx["pr"], thresh="0.01 mm d-1"
+            )
+            dhistx["pr"] = xc.sdba.processing.jitter_under_thresh(
+                dhistx["pr"], thresh="0.01 mm d-1"
+            )
+
+            dhist_ad, pth, dP0 = xc.sdba.processing.adapt_freq(
+                drefx["pr"], dhistx["pr"], group=group, thresh="1 mm d-1"
+            )
+
+            QM = xc.sdba.DetrendedQuantileMapping.train(
+                drefx["pr"], dhist_ad, group=group, kind="*", nquantiles=50
+            )
+
+            detrend = xc.sdba.detrending.LoessDetrend(
+                f=0.2, niter=1, d=0, weights="tricube", group=group, kind="*"
+            )
+            out_xclim = QM.adjust(
+                dsimx["pr"], detrend=detrend, interp="nearest", extrapolation="constant"
+            ).rename({"scen": "pr"})
+
+        assert out_xscen.equals(out_xclim)
+
+    # mayeb don't need if we remove the arg ?
+    # def test_window(self):
+    #     dtrain = xs.train(
+    #         self.dref,
+    #         self.dsim.sel(time=slice("2001", "2003")),
+    #         method='ExtremeValues',
+    #         group=False,
+    #         xclim_train_args={'cluster_thresh': "2 degC", "q_thresh": 0.95},
+    #         var="tas",
+    #         period=["2001", "2003"],
+    #     )
+    #
+    #
+    #     out = xs.adjust(self.dtrain,
+    #                     self.dsim,
+    #                     periods=['2001', '2006'],
+    #                     xclim_adjust_args={'scen': scen,
+    #                                        'frac': 0.25},
+    #                     moving_yearly_window={'window': 2, 'step': 1},
+    #                     )

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -242,7 +242,6 @@ class TestAdjust:
     def test_xclim_vs_xscen(
         self,
     ):  # should give the same results  using xscen and xclim
-
         dref = (
             timeseries(
                 dask.array.from_array(
@@ -277,7 +276,7 @@ class TestAdjust:
             var="pr",
             period=["2001", "2003"],
             adapt_freq={"thresh": "1 mm d-1"},
-            jitter_under={"thresh": "0.01 mm d-1"},
+            # jitter_under={"thresh": "0.01 mm d-1"},
             xclim_train_args={"kind": "*", "nquantiles": 50},
         )
 
@@ -308,12 +307,12 @@ class TestAdjust:
                 dsim.sel(time=slice("2001", "2006")), "noleap"
             )
 
-            drefx["pr"] = xc.sdba.processing.jitter_under_thresh(
-                drefx["pr"], thresh="0.01 mm d-1"
-            )
-            dhistx["pr"] = xc.sdba.processing.jitter_under_thresh(
-                dhistx["pr"], thresh="0.01 mm d-1"
-            )
+            # drefx["pr"] = xc.sdba.processing.jitter_under_thresh(
+            #     drefx["pr"], thresh="0.01 mm d-1"
+            # )
+            # dhistx["pr"] = xc.sdba.processing.jitter_under_thresh(
+            #     dhistx["pr"], thresh="0.01 mm d-1"
+            # )
 
             dhist_ad, pth, dP0 = xc.sdba.processing.adapt_freq(
                 drefx["pr"], dhistx["pr"], group=group, thresh="1 mm d-1"

--- a/xscen/biasadjust.py
+++ b/xscen/biasadjust.py
@@ -298,8 +298,6 @@ def adjust(
 
     dscen = _add_preprocessing_attr(dscen, dtrain.attrs["train_params"])
     dscen = xr.Dataset(data_vars={var: dscen}, attrs=dsim.attrs)
-    # TODO: History, attrs, etc. (TODO kept from previous version of `biasadjust`)
-    # TODO: Check for variables to add (grid_mapping, etc.) (TODO kept from previous version of `biasadjust`)
     dscen.attrs["cat:processing_level"] = to_level
     dscen.attrs["cat:variable"] = parse_from_ds(dscen, ["variable"])["variable"]
     if bias_adjust_institution is not None:

--- a/xscen/biasadjust.py
+++ b/xscen/biasadjust.py
@@ -15,6 +15,7 @@ from .config import parse_config
 from .utils import minimum_calendar, standardize_periods
 
 logger = logging.getLogger(__name__)
+xc.set_options(sdba_encode_cf=True, sdba_extra_output=False)
 
 
 __all__ = [
@@ -287,9 +288,8 @@ def adjust(
             kwargs.setdefault("kind", ADJ.kind)
             xclim_adjust_args["detrend"] = getattr(sdba.detrending, name)(**kwargs)
 
-        with xc.set_options(sdba_encode_cf=True, sdba_extra_output=False):
-            out = ADJ.adjust(sim_sel, **xclim_adjust_args)
-            slices.extend([out])
+        out = ADJ.adjust(sim_sel, **xclim_adjust_args)
+        slices.extend([out])
     # put all the adjusted period back together
     dscen = xr.concat(slices, dim="time")
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* add bias adjust tests
* fixed a few bugs:
  * Removed train from the inside the period for loop. Only need to do it once and bugged with group if inside loop.
  * fix `_add_preprocessing_attr` that was not actually modifying the attrs
  * Change way of defining default group

### Does this PR introduce a breaking change?
*`adjust` won't fail if dict group and many periods.
*`preprocessing_attrs` will actually be added
* If pass `group=False`, it will actually be False.

### Other information:

1. Is it ok to remove the TODOs ? I'm not sure exactly what they were referring to, I don't think they are relevant anymore.
2. I suggest removing `moving_yearly_window` I am not actually using the args for info-crue cmip6 and the function has changed name in xclim.
