### PR TITLE
Make xscen.utils.change_units() update unit name on equal units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.9.0 (unreleased)
 -------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user: `juliettelavoie`), Marco Braun (:user:`vindelico`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user: `juliettelavoie`), Marco Braun (:user: `vindelico`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Breaking changes
 
 Internal changes
 ^^^^^^^^^^^^^^^^
-* Updated ``xscen.utils.change_unit`` to update unit name if the physical units are equal but not their name (ex. degC vs °C) (:pull:`358`).
+* Updated ``xscen.utils.change_unit`` to update unit name if the physical units are equal but not their name (ex. degC vs °C) (:pull:`373`).
 * Updated the `cookiecutter` template to the latest version. (:pull:`358`):
     * Addresses a handful of misconfigurations in the GitHub Workflows.
     * Added a few free `grep`-based hooks for finding unwanted artifacts in the code base.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.9.0 (unreleased)
 -------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user: `juliettelavoie`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user: `juliettelavoie`), Marco Braun (:user:`vindelico`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -14,6 +14,7 @@ Breaking changes
 
 Internal changes
 ^^^^^^^^^^^^^^^^
+* Updated ``xscen.utils.change_unit`` to update unit name if the physical units are equal but not their name (ex. degC vs °C) (:pull:`358`).
 * Updated the `cookiecutter` template to the latest version. (:pull:`358`):
     * Addresses a handful of misconfigurations in the GitHub Workflows.
     * Added a few free `grep`-based hooks for finding unwanted artifacts in the code base.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.9.0 (unreleased)
 -------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user: `juliettelavoie`), Marco Braun (:user: `vindelico`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Marco Braun (:user:`vindelico`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Breaking changes
 
 Internal changes
 ^^^^^^^^^^^^^^^^
-* Updated ``xscen.utils.change_unit`` to update unit name if the physical units are equal but not their name (ex. degC vs °C) (:pull:`373`).
+* Modified ``xscen.utils.change_unit`` to always adopt the name from the `variables_and_units dictionary` if the physical units are equal but their names are not (ex. degC <-> ˚C) (:pull:`373`).
 * Updated the `cookiecutter` template to the latest version. (:pull:`358`):
     * Addresses a handful of misconfigurations in the GitHub Workflows.
     * Added a few free `grep`-based hooks for finding unwanted artifacts in the code base.

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -718,6 +718,9 @@ def change_units(ds: xr.Dataset, variables_and_units: dict) -> xr.Dataset:
                     raise NotImplementedError(
                         f"No known transformation between {ds[v].units} and {variables_and_units[v]} (temporal dimensionality mismatch)."
                     )
+            elif (v in ds) and (ds[v].units != variables_and_units[v]):
+                # update unit name if units are equal but not the name (ex. degC vs °C)
+                ds[v] = ds[v].assign_attrs(units=variables_and_units[v])
 
     return ds
 

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -719,7 +719,7 @@ def change_units(ds: xr.Dataset, variables_and_units: dict) -> xr.Dataset:
                         f"No known transformation between {ds[v].units} and {variables_and_units[v]} (temporal dimensionality mismatch)."
                     )
             elif (v in ds) and (ds[v].units != variables_and_units[v]):
-                # update unit name if units are equal but not the name (ex. degC vs °C)
+                # update unit name if physical units are equal but not their name (ex. degC vs °C)
                 ds[v] = ds[v].assign_attrs(units=variables_and_units[v])
 
     return ds


### PR DESCRIPTION
Make xscen.utils.change_units() update unit name on equal units

<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

During unit conversion ``xscen.utils.change_units`` will adopt the name from the `variables_and_units` dictionary if the physical units are equal but their names are not (ex. degC <-> ˚C) 

Useful for harmonizing unit names when processing datasets of varying origin.

### Does this PR introduce a breaking change?

No.

### Other information:

There is no testing for xscen.utils (yet). Right?
