### PR TITLE
Ensure that chunking is respected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Bug fixes
 * Fixed a bug to accept `group = False` in `adjust` function. (:pull:`366`).
 * `creep_weights` now correctly handles the case where the grid is small, `n` is large, and `mode=wrap`. (:issue:`367`).
 * Fixed a bug in ``tasmin_from_dtr`` and ``tasmax_from_dtr``, when `dtr` units differed from tasmin/max. (:pull:`372`).
+* Fixed a bug where the requested chunking would be ignored when saving a dataset (:pull:`379`).
 
 v0.8.3 (2024-02-28)
 -------------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -35,7 +35,7 @@ dependencies:
   - zarr
   # Opt
   - nc-time-axis >=1.3.1
-  - pyarrow >=1.0.0
+  - pyarrow >=10.0.1
   # Dev
   - babel
   - black ==24.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -37,5 +37,5 @@ dependencies:
   - babel
   # Opt
   - nc-time-axis >=1.3.1
-  - pyarrow >=1.0.0
+  - pyarrow >=10.0.1
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "pandas >=2.2",
   "parse",
   # Used when opening catalogs.
-  "pyarrow",
+  "pyarrow>=10.0.1",
   "pyyaml",
   "rechunker",
   "scipy",


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `original_shape` and `chunksizes` don't play well together. This PR makes sure that `original_shape` is always removed before saving a dataset.
* Also, (maybe new in the latest version of `xarray` and engine `netcdf4`?), it appears that dropping `chunksizes` leads to unexpected behaviours, such as bloated file size and incorrect chunking on disk. Thus, the `chunksizes` encoding was made more explicit.

### Does this PR introduce a breaking change?

* No.


### Other information:

Related Issues:
https://github.com/pydata/xarray/issues/8385
https://github.com/pydata/xarray/issues/8062
