### PR TITLE
Guess cf coords before subsetting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Internal changes
 * Refactored ``xs.spatial.subset`` into smaller functions. (:pull:`367`).
 * An `encoding` argument was added to ``xs.config.load_config``. (:pull:`370`).
 * Various small fixes to the code to address FutureWarnings. (:pull:`380`).
+* ``xs.spatial.subset`` will try to guess CF coordinate if it can't find "latitude" or "longitude" in ``ds.cf``. (:pull:`384`).
 
 Bug fixes
 ^^^^^^^^^

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -275,6 +275,20 @@ class TestSubset:
         with pytest.raises(ValueError, match="Subsetting type not recognized"):
             xs.spatial.subset(self.ds, "wrong", lon=-70, lat=45)
 
+    def test_subset_no_attributes(self):
+        ds = self.ds.copy()
+        ds.lat.attrs = {}
+        ds.lon.attrs = {}
+        assert "latitude" not in ds.cf
+
+        xs.spatial.subset(
+            ds,
+            "bbox",
+            name="test",
+            lon_bnds=[-63, -60],
+            lat_bnds=[47, 50],
+        )
+
 
 def test_dask_coords():
     ds = datablock_3d(

--- a/xscen/spatial.py
+++ b/xscen/spatial.py
@@ -183,7 +183,7 @@ def subset(
             UserWarning,
         )
 
-    if "latitude" not in ds.cf:
+    if "latitude" not in ds.cf or "longitude" not in ds.cf:
         ds = ds.cf.guess_coord_axis()
 
     if method == "gridpoint":

--- a/xscen/spatial.py
+++ b/xscen/spatial.py
@@ -183,6 +183,9 @@ def subset(
             UserWarning,
         )
 
+    if "latitude" not in ds.cf:
+        ds = ds.cf.guess_coord_axis()
+
     if method == "gridpoint":
         ds_subset = _subset_gridpoint(ds, name=name, **kwargs)
     elif method == "bbox":


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* If  one of  "longitude" or "latitude" can't be found in the CF-compliant coordinates of the input dataset, `spatial.subset` will try to guess them ( `cf-xarray` does it really).

### Does this PR introduce a breaking change?
No. Nothing is touched if coordinates are present. If they can't be found, it will fail silently and we can expect the `subset` to fail further down the line with some (hopefully) explicit message.


### Other information
This allows the seamless usage of `extract_dataset` with datasets which lack proper attributes on their coordinates (our copy of ERA5, for example).