### PR TITLE
Fix robustness tests for xclim 0.48.3-dev9

### DIFF
--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -180,7 +180,11 @@ class TestEnsembleStats:
 
         out = xs.ensemble_stats(ens, statistics=statistics, weights=weights)
 
-        assert len(out.data_vars) == {"only": 5, "both": 6, "nested": 1}[fractions]
+        # Output length should be 1 if nested, >=5 otherwise
+        if fractions == "nested":
+            assert len(out.data_vars) == 1
+        else:
+            assert len(out.data_vars) >= 5
         if fractions in ["only", "both"]:
             np.testing.assert_array_equal(out.tg_mean_changed, [0, 0.4, 1, 1])
             np.testing.assert_array_equal(out.tg_mean_agree, [1, 1, 1, 1])


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #385 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* The latest changes to `xclim` have added 2 outputs to `robustness_fractions`, so our tests would have started to fail with the next release. This should fix it, while still supporting the current number of outputs.

### Does this PR introduce a breaking change?

* No.

### Other information:
