### PR TITLE
Fixes for xclim 0.50 - Better defaults for opening

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Internal changes
 * An `encoding` argument was added to ``xs.config.load_config``. (:pull:`370`).
 * Various small fixes to the code to address FutureWarnings. (:pull:`380`).
 * ``xs.spatial.subset`` will try to guess CF coordinate if it can't find "latitude" or "longitude" in ``ds.cf``. (:pull:`384`).
+* ``xs.extract_dataset`` and ``xs.DataCatalog.to_dataset`` will now default to opening datasets with option ``chunks={}``, which tries to respect chunking on disk. (:pull:`398`, :issue:`368`).
 
 Bug fixes
 ^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,11 @@ exclude = [
   "build",
   "docs"
 ]
+
+[tool.ruff.format]
+line-ending = "auto"
+
+[tool.ruff.lint]
 ignore = [
   "D205",
   "D400",
@@ -214,9 +219,6 @@ select = [
   "F",
   "W"
 ]
-
-[tool.ruff.format]
-line-ending = "auto"
 
 [tool.ruff.lint.flake8-bandit]
 check-typed-exception = true

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -119,21 +119,6 @@ class TestEnsembleStats:
             decimal=2,
         )
 
-    # FIXME: This function is deprecated, so this test should be removed eventually.
-    @pytest.mark.parametrize("p_vals", [True, False])
-    def test_change_significance(self, p_vals):
-        ens = self.make_ensemble(10)
-        with pytest.warns(
-            FutureWarning,
-            match="Function change_significance is deprecated as of xclim 0.47",
-        ):
-            out = xs.ensemble_stats(
-                ens,
-                statistics={"change_significance": {"test": None, "p_vals": p_vals}},
-            )
-
-        assert len(out.data_vars) == 3 if p_vals else 2
-
     @pytest.mark.parametrize("fractions", ["only", "both", "nested", "missing"])
     def test_robustness_input(self, fractions):
         ens = self.make_ensemble(10)

--- a/xscen/catalog.py
+++ b/xscen/catalog.py
@@ -23,6 +23,7 @@ from intake_esm.cat import ESMCatalogModel
 
 from .config import CONFIG, args_as_str, recursive_update
 from .utils import (
+    _xarray_defaults,
     date_parser,
     ensure_correct_time,
     ensure_new_xrfreq,
@@ -529,6 +530,9 @@ class DataCatalog(intake_esm.esm_datastore):
             raise ValueError(
                 f"Expected exactly one dataset, received {N} instead : {cat.keys()}"
             )
+
+        kwargs = _xarray_defaults(**kwargs)
+
         ds = cat.to_dask(**kwargs)
         return ds
 

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -29,7 +29,7 @@ from .catutils import parse_from_ds
 from .config import parse_config
 from .indicators import load_xclim_module, registry_from_module
 from .spatial import subset
-from .utils import CV
+from .utils import CV, _xarray_kwargs
 from .utils import ensure_correct_time as _ensure_correct_time
 from .utils import get_cat_attrs, natural_sort, standardize_periods, xrfreq_to_timedelta
 
@@ -161,17 +161,16 @@ def extract_dataset(  # noqa: C901
         }
 
     # Default arguments to send xarray
-    xr_open_kwargs = xr_open_kwargs or {}
-    xr_combine_kwargs = xr_combine_kwargs or {}
-    xr_combine_kwargs.setdefault("data_vars", "minimal")
+    xr_kwargs = _xarray_kwargs(
+        xr_open_kwargs=xr_open_kwargs or {}, xr_combine_kwargs=xr_combine_kwargs or {}
+    )
 
     # Open the catalog
     ds_dict = catalog.to_dataset_dict(
-        xarray_open_kwargs=xr_open_kwargs,
-        xarray_combine_by_coords_kwargs=xr_combine_kwargs,
         preprocess=preprocess,
         # Only print a progress bar when it is minimally useful
         progressbar=(len(catalog.keys()) > 1),
+        **xr_kwargs,
     )
 
     out_dict = {}

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -29,7 +29,7 @@ from .catutils import parse_from_ds
 from .config import parse_config
 from .indicators import load_xclim_module, registry_from_module
 from .spatial import subset
-from .utils import CV, _xarray_kwargs
+from .utils import CV, _xarray_defaults
 from .utils import ensure_correct_time as _ensure_correct_time
 from .utils import get_cat_attrs, natural_sort, standardize_periods, xrfreq_to_timedelta
 
@@ -161,7 +161,7 @@ def extract_dataset(  # noqa: C901
         }
 
     # Default arguments to send xarray
-    xr_kwargs = _xarray_kwargs(
+    xr_kwargs = _xarray_defaults(
         xr_open_kwargs=xr_open_kwargs or {}, xr_combine_kwargs=xr_combine_kwargs or {}
     )
 

--- a/xscen/indicators.py
+++ b/xscen/indicators.py
@@ -134,7 +134,7 @@ def compute_indicators(  # noqa: C901
             ind.injected_parameters["freq"]
             if "freq" in ind.injected_parameters
             else (
-                ind.parameters["freq"]["default"]
+                ind.parameters["freq"].default
                 if "freq" in ind.parameters
                 else ind.src_freq
             )

--- a/xscen/utils.py
+++ b/xscen/utils.py
@@ -1402,3 +1402,17 @@ def ensure_new_xrfreq(freq: str) -> str:  # noqa: C901
         freq = freq.replace("U", "us")
 
     return freq
+
+
+def _xarray_defaults(**kwargs):
+    """Translate from xscen's extract names to intake-esm names and put better defaults."""
+    if "xr_open_kwargs" in kwargs:
+        kwargs["xarray_open_kwargs"] = kwargs.pop("xr_open_kwargs")
+    if "xr_combine_kwargs" in kwargs:
+        kwargs["xarray_combine_by_coords_kwargs"] = kwargs.pop("xr_combine_kwargs")
+
+    kwargs.setdefault("xarray_open_kwargs", {}).setdefault("chunks", {})
+    kwargs.setdefault("xarray_combine_by_coords_kwargs", {}).setdefault(
+        "data_vars", "minimal"
+    )
+    return kwargs


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #394
    - This PR fixes #368  
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fix usage of `xclim.core.indicator.Parameter` to fit xclim's deprecation of the dict-like access.
* Remove `change_significance` test for  `ensemble_stats`, function was removed from xclim.
* Both `extract_dataset` and `to_dataset` will default to `chunks={}`.

### Does this PR introduce a breaking change?
No.

### Other information:
