### PR TITLE
Fix `xr_combine_kwargs` in extract_dataset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.9.1 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Fixed defaults for ``xr_combine_kwargs`` in ``extract_dataset`` (:pull:`402`).
+
 v0.9.0 (2024-05-07)
 -------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Marco Braun (:user:`vindelico`).

--- a/xscen/extract.py
+++ b/xscen/extract.py
@@ -281,7 +281,9 @@ def extract_dataset(  # noqa: C901
             slices = []
             for period in periods_extract:
                 slices.extend([ds.sel({"time": slice(period[0], period[1])})])
-            ds = xr.concat(slices, dim="time", **xr_combine_kwargs)
+            ds = xr.concat(
+                slices, dim="time", **xr_kwargs["xarray_combine_by_coords_kwargs"]
+            )
 
         # subset to the region
         if region is not None:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* In #398, I introduced a new way of setting defaults for `xr_combine_kwargs` in `extract_dataset`, but I missed one use of the argument, which make `extract_dataset` fail when nothing is given to the argument.

### Does this PR introduce a breaking change?
No.


### Other information:
Seen by Dominic et Oumou.