### PR TITLE
Dont change mutable input argument of search_data_catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.9.2 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Avoid modification of mutable arguments in ``search_data_catalogs`` (:pull:`413`).
+
 v0.9.1 (2024-06-04)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`).


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Rewrite the first part of `search_data_catalogs` so that we do not modify the mutable input argument `data_catalogs`. 

If this argument is coming from a config dictionary, this had the unwanted consquence of changing the config entry from a path to a `DataCatalog` instance. Which could have unexpected consequences.

In our usual xscen usage, the config dictionary is an instance of `xscen.config.ConfigDict` which has the magical ability of copying itself each time a section is accessed (i.e. `CONFIG['section']` actually returns a copy of the "section" sub-dictionary and not a reference to the `CONFIG` dictionary itself.). And so we didn't notice the issue.

### Does this PR introduce a breaking change?
I hope not.

### Other information:
