### PR TITLE
fix multiindex unstack future warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Internal changes
 * Include domain in `weight_location` in ``regrid_dataset``. (:pull:`414`).
 * Added pins to `xarray`, `xclim`, `h5py`, and `netcdf4`. (:pull:`414`).
 * Add ``.zip`` and ``.zarr.zip`` as possible file extensions for Zarr datasets. (:pull:`426`).
+* Explicitly assign coords of multiindex in `xs.unstack_fill_nan`. (:pull:`427`).
 
 v0.9.1 (2024-06-04)
 -------------------

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -476,11 +476,11 @@ def unstack_fill_nan(
                 ]
             )
 
-        out = (
-            ds.drop_vars(dims)
-            .assign_coords({dim: pd.MultiIndex.from_arrays(crds, names=dims)})
-            .unstack(dim)
-        )
+        # explicitly get lat and lon
+        mindex_obj = pd.MultiIndex.from_arrays(crds, names=dims)
+        mindex_coords = xr.Coordinates.from_pandas_multiindex(mindex_obj, dim)
+
+        out = ds.drop_vars(dims).assign_coords(mindex_coords).unstack(dim)
 
         if not isinstance(coords, (list, tuple)) and coords is not None:
             out = out.reindex(**coords.coords)

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -453,11 +453,11 @@ def unstack_fill_nan(
                 if crd.dims == (dim,) and name in coords_and_dims
             ]
         )
-        out = (
-            ds.drop_vars(dims)
-            .assign_coords({dim: pd.MultiIndex.from_arrays(crds, names=dims)})
-            .unstack(dim)
-        )
+
+        mindex_obj = pd.MultiIndex.from_arrays(crds, names=dims)
+        mindex_coords = xr.Coordinates.from_pandas_multiindex(mindex_obj, dim)
+
+        out = ds.drop_vars(dims).assign_coords(mindex_coords).unstack(dim)
 
         # only reindex with the dims
         out = out.reindex(**coords_and_dims)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* explicitely assign the lat and lon coords of the lov multiindex.
* in response to: 
```
/tmp/ipykernel_94931/2504572846.py:29: FutureWarning: the `pandas.MultiIndex` object(s) passed as 'loc' coordinate(s) or data variable(s) will no longer be implicitly promoted and wrapped into multiple indexed coordinates in the future (i.e., one coordinate for each multi-index level + one dimension coordinate). If you want to keep this behavior, you need to first wrap it explicitly using `mindex_coords = xarray.Coordinates.from_pandas_multiindex(mindex_obj, 'dim')` and pass it as coordinates, e.g., `xarray.Dataset(coords=mindex_coords)`, `dataset.assign_coords(mindex_coords)` or `dataarray.assign_coords(mindex_coords)`.
```

### Does this PR introduce a breaking change?
no

### Other information:
