### PR TITLE
Unpin cartopy

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   # Don't forget to sync changes between environment.yml, environment-dev.yml, and setup.py!
   # Also consider updating the list in xs.utils.show_versions if you add a new package.
   # Main packages
-  - cartopy >=0.23.0
+  - cartopy
   - cftime
   - cf_xarray >=0.7.6
   - clisops >=0.10

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   # Don't forget to sync changes between environment.yml, environment-dev.yml, and setup.py!
   # Also consider updating the list in xs.utils.show_versions if you add a new package.
   # Main packages
-  - cartopy >=0.23.0
+  - cartopy
   - cftime
   - cf_xarray >=0.7.6
   - clisops >=0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "babel",
-  "cartopy >=0.23.0",
+  "cartopy",
   "cftime",
   "cf_xarray >=0.7.6",
   "clisops >=0.10",


### PR DESCRIPTION
Cartopy was pinned in #403. I think this was because of the change of license. However, cartopy 0.23 is not available on Narval and before asking for it, I wanted to be sure I could argument for it.

After searching a bit, I think we do not need to pin as previous cartopy versions were released under the "LGPL", _not GPL_. LGPL allows dynamical linking, which is what a `import` does, to my knowledge.
See discussions :
https://opensource.stackexchange.com/questions/9470/can-i-sell-a-proprietary-software-with-an-lgpl-library-bundled-along-with-it-wi
and
https://stackoverflow.com/questions/8580223/using-python-module-on-lgpl-license-in-commercial-product