### PR TITLE
Fix buffer CRS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,15 @@ Changelog
 
 v0.9.2 (unreleased)
 -------------------
-Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
 Bug fixes
 ^^^^^^^^^
 * Fixed bug with reusing weights. (:issue:`411`, :pull:`414`).
 * Fixed bug in `update_from_ds` when "time" is a coordinate, but not a dimension. (:pull: `417`).
 * Avoid modification of mutable arguments in ``search_data_catalogs`` (:pull:`413`).
+* ``ensure_correct_time`` now correctly handles cases where timesteps are missing. (:pull:`440`).
+* If using the argument `tile_buffer` with a `shape` method in ``spatial.subset``, the shapefile will now be reprojected to a WGS84 grid before the buffer is applied. (:pull:`440`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/spatial.py
+++ b/src/xscen/spatial.py
@@ -362,19 +362,22 @@ def _subset_shape(
         # The buffer argument needs to be in the same units as the shapefile, so it's simpler to always project the shapefile to WGS84.
         if isinstance(shape, (str, Path)):
             shape = gpd.read_file(shape)
+
         try:
             shape_crs = shape.crs
-            if (shape_crs is not None) and (shape_crs != CRS(4326)):  # WGS84
-                warnings.warn(
-                    "Shapefile is not in EPSG:4326. Reprojecting to this CRS.",
-                    UserWarning,
-                )
-                shape = shape.to_crs(4326)
         except AttributeError:
+            shape_crs = None
+        if shape_crs is None:
             warnings.warn(
-                "Shapefile does not have a CRS. Compatability with the dataset is not guaranteed.",
+                "Shapefile does not have a CRS. Compatibility with the dataset is not guaranteed.",
+                category=UserWarning,
+            )
+        elif shape_crs != CRS(4326):  # WGS84
+            warnings.warn(
+                "Shapefile is not in EPSG:4326. Reprojecting to this CRS.",
                 UserWarning,
             )
+            shape = shape.to_crs(4326)
 
         kwargs["buffer"] = np.max([lon_res, lat_res]) * tile_buffer
 

--- a/src/xscen/spatial.py
+++ b/src/xscen/spatial.py
@@ -364,7 +364,7 @@ def _subset_shape(
             shape = gpd.read_file(shape)
         try:
             shape_crs = shape.crs
-            if shape_crs != CRS(4326):  # WGS84
+            if (shape_crs is not None) and (shape_crs != CRS(4326)):  # WGS84
                 warnings.warn(
                     "Shapefile is not in EPSG:4326. Reprojecting to this CRS.",
                     UserWarning,

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -855,7 +855,9 @@ def clean_up(  # noqa: C901
                 logging.info(f"Filling missing {var} with {missing}")
                 if missing == "interpolate":
                     ds_with_nan = ds[var].where(ds[var] != -9999)
-                    converted_var = ds_with_nan.interpolate_na("time", method="linear")
+                    converted_var = ds_with_nan.chunk({"time": -1}).interpolate_na(
+                        "time", method="linear"
+                    )
                 else:
                     var_attrs = ds[var].attrs
                     converted_var = xr.where(ds[var] == -9999, missing, ds[var])

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -1273,9 +1273,9 @@ def ensure_correct_time(ds: xr.Dataset, xrfreq: str) -> xr.Dataset:
                 "Dataset is labelled as having a sampling frequency of "
                 f"{xrfreq}, but some periods have more than one data point."
             )
-        if (counts.isnull()).any().item():
+        if (counts.isnull() | (counts == 0)).any().item():
             raise ValueError(
-                "The resampling count contains nans. There might be some missing data."
+                "The resampling count contains NaNs or 0s. There might be some missing data."
             )
         ds["time"] = counts.time
     return ds


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* The buffer argument in `_subset_shape` needs to be in the same units as the shapefile, so it's simpler to always project the shapefile to WGS84 before the call to `clisops`, when using `tile_buffer`.
* Also a small fix in `ensure_time` to accurately catch missing timesteps.

### Does this PR introduce a breaking change?

* This changes the behaviour, but this is a bug fix.

### Other information:
