### PR TITLE
Added teststo `utils.py` and fixed bugs

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,67 @@
 from datetime import datetime
+from pathlib import Path
 
 import cftime
+import dask.array
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+import xclim as xc
 from xclim.testing.helpers import test_timeseries as timeseries
 
 import xscen as xs
 from xscen.testing import datablock_3d
+
+
+class TestLocale:
+    def test_update(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 366), 30),
+            variable="tas",
+            start="2001-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        indicator = xc.core.indicator.Indicator.from_dict(
+            data={"base": "tg_mean"},
+            identifier="tg_mean",
+            module="atmos",
+        )
+        with xc.set_options(metadata_locales="fr"):
+            out = xs.compute_indicators(ds, [("tg_mean", indicator)])["YS-JAN"]
+        out = xs.climatological_op(out, op="mean")
+
+        assert (
+            out["tg_mean_clim_mean"].attrs["long_name"]
+            == "30-year climatological average of Mean daily mean temperature."
+        )
+        assert (
+            out["tg_mean_clim_mean"].attrs["long_name_fr"]
+            == "Moyenne 30 ans de Moyenne de la température moyenne quotidienne."
+        )
+
+    @pytest.mark.parametrize("locale", ["fr", "jp"])
+    def test_add(self, locale):
+        # Dummy function to make gettext aware of translatable-strings
+        def _(s):
+            return s
+
+        ds = timeseries(
+            np.arange(1, 366),
+            variable="tas",
+            start="2001-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        with xc.set_options(metadata_locales=locale):
+            xs.utils.add_attr(ds, "some_attr", _("Ranking of measure performance"))
+        assert ds.attrs["some_attr"] == "Ranking of measure performance"
+        if locale == "fr":
+            assert ds.attrs["some_attr_fr"] == "Classement de performance de la mesure"
+        elif locale == "jp":
+            # Japanese translation is not available, so the original string is used
+            assert ds.attrs["some_attr_jp"] == "Ranking of measure performance"
 
 
 class TestDateParser:
@@ -40,6 +93,12 @@ class TestDateParser:
             ),
             ("abc", None, "datetime", pd.Timestamp("NaT")),
             ("", True, "datetime", pd.Timestamp("NaT")),
+            (
+                pd.Period("2001-07-08", "H"),
+                None,
+                "datetime",
+                pd.Timestamp("2001-07-08"),
+            ),
         ],
     )
     def test_normal(self, date, end_of_period, dtype, exp):
@@ -50,12 +109,100 @@ class TestDateParser:
             assert out == exp
 
 
+class TestMinCal:
+    @pytest.mark.parametrize(
+        "cals",
+        [
+            ["360_day", "365_day"],
+            ["365_day", "default"],
+            ["noleap", "default"],
+            ["365_day", "noleap"],
+            ["365_day", "all_leap"],
+            ["366_day", "all_leap"],
+            ["366_day", "default"],
+        ],
+    )
+    def test_minimum_calendar(self, cals):
+        out = xs.utils.minimum_calendar(cals)
+        if "360_day" in cals:
+            assert out == "360_day"
+        elif any(c in cals for c in ["noleap", "365_day"]):
+            assert out == "noleap"
+        elif any(c in cals for c in ["default", "standard"]):
+            assert out == "standard"
+        else:
+            assert out == "all_leap"
+
+    def test_error(self):
+        with pytest.raises(ValueError):
+            xs.utils.minimum_calendar(["366_day", "foo"])
+
+
+class TestTranslateTimeChunk:
+    @pytest.mark.parametrize("chunk", [-1, 10])
+    def test_normal(self, chunk):
+        out = xs.utils.translate_time_chunk({"time": chunk, "lon": 50}, "noleap", 3450)
+        assert out == {"time": 3450 if chunk == -1 else 10, "lon": 50}
+
+    @pytest.mark.parametrize("calendar", ["360_day", "standard", "365_day", "366_day"])
+    def test_ny(self, calendar):
+        ndays = int(calendar.split("_")[0]) if "day" in calendar else 365.25
+        out = xs.utils.translate_time_chunk(
+            {"time": "4year", "lon": 50}, calendar, 3450
+        )
+        assert out == {"time": ndays * 4, "lon": 50}
+
+    def test_dict_of_dict(self):
+        out = xs.utils.translate_time_chunk(
+            {"tas": {"time": 10, "lon": 50}, "pr": {"time": -1, "lon": 50}},
+            "noleap",
+            3450,
+        )
+        assert out == {"tas": {"time": 10, "lon": 50}, "pr": {"time": 3450, "lon": 50}}
+
+
+def test_naturalsort():
+    assert xs.utils.natural_sort(["r1i1p1", "r2i1p1", "r10i1p1", "r1i1p2"]) == [
+        "r1i1p1",
+        "r1i1p2",
+        "r2i1p1",
+        "r10i1p1",
+    ]
+
+
+def get_cat_attrs():
+    ds = timeseries(
+        np.tile(np.arange(1, 2), 50),
+        variable="tas",
+        start="2000-01-01",
+        freq="YS-JAN",
+        as_dataset=True,
+    )
+    ds.attrs = {
+        "foo": "bar",
+        "cat:type": "simulation",
+        "cat:variable": ("tas",),
+        "dog:source": "CanESM5",
+    }
+
+    assert xs.utils.get_cat_attrs(ds) == {"type": "simulation", "variable": ("tas",)}
+    assert xs.utils.get_cat_attrs(ds, var_as_str=True) == {
+        "type": "simulation",
+        "variable": "tas",
+    }
+    assert xs.utils.get_cat_attrs(ds, prefix="dog:") == {"source": "CanESM5"}
+    assert xs.utils.get_cat_attrs(ds.attrs) == {
+        "type": "simulation",
+        "variable": ("tas",),
+    }
+
+
 class TestScripting:
     ds = timeseries(
         np.tile(np.arange(1, 2), 50),
         variable="tas",
         start="2000-01-01",
-        freq="AS-JAN",
+        freq="YS-JAN",
         as_dataset=True,
     )
     ds.attrs = {
@@ -66,10 +213,12 @@ class TestScripting:
     }
 
     @pytest.mark.parametrize(
-        "prefix, var_as_str", [["cat:", False], ["cat:", True], ["dog:", True]]
+        "ds, prefix, var_as_str",
+        [["ds", "cat:", False], ["dict", "cat:", True], ["ds", "dog:", True]],
     )
-    def test_get_cat_attrs(self, prefix, var_as_str):
-        out = xs.utils.get_cat_attrs(self.ds, prefix=prefix, var_as_str=var_as_str)
+    def test_get_cat_attrs(self, ds, prefix, var_as_str):
+        data = self.ds if ds == "ds" else self.ds.attrs
+        out = xs.utils.get_cat_attrs(data, prefix=prefix, var_as_str=var_as_str)
 
         if var_as_str and prefix == "cat:":
             assert out == {
@@ -87,8 +236,7 @@ class TestScripting:
             assert out == {"source": "CanESM5"}
 
 
-class TestStackNan:
-
+class TestStack:
     def test_no_nan(self):
         ds = datablock_3d(
             np.zeros((20, 10, 10)),
@@ -132,13 +280,858 @@ class TestStackNan:
             ds,
             mask=mask,
             new_dim="loc1",
-            to_file=str(tmp_path / "coords_{domain}_{shape}.nc"),
+            to_file=str(tmp_path / "subfolder" / "coords_{domain}_{shape}.nc"),
         )
         assert "loc1" in out.dims
         assert out.sizes["loc1"] == 99
-        assert (tmp_path / "coords_RegionEssai_10x10.nc").is_file()
+        assert (tmp_path / "subfolder" / "coords_RegionEssai_10x10.nc").is_file()
+
+        out_no_mask = xs.utils.stack_drop_nans(ds, mask=["lon", "lat"], new_dim="loc1")
+        assert out_no_mask.equals(out)
 
         ds_unstack = xs.utils.unstack_fill_nan(
-            out, dim="loc1", coords=str(tmp_path / "coords_{domain}_{shape}.nc")
+            out,
+            dim="loc1",
+            coords=str(tmp_path / "subfolder" / "coords_{domain}_{shape}.nc"),
         )
         assert ds_unstack.equals(ds)
+
+    def test_maybe(self, tmp_path):
+        data = np.zeros((20, 10, 10))
+        data[:, 0, 0] = [np.nan] * 20
+        ds = datablock_3d(
+            data,
+            "tas",
+            "lon",
+            -5,
+            "lat",
+            80.5,
+            1,
+            1,
+            "2000-01-01",
+            as_dataset=True,
+        )
+        mask = xr.where(ds.tas.isel(time=0).isnull(), False, True).drop_vars("time")
+        ds.attrs["cat:domain"] = "RegionEssai"
+        z = xr.DataArray(
+            np.ones([10, 10]),
+            dims=["lat", "lon"],
+            coords={"lat": ds.lat, "lon": ds.lon},
+        )
+        z1d = xr.DataArray(np.ones([10]), dims=["lat"], coords={"lat": ds.lat})
+        ds = ds.assign_coords(z=z, z1d=z1d)
+        out = xs.utils.stack_drop_nans(
+            ds,
+            mask=mask,
+            new_dim="loc1",
+            to_file=str(tmp_path / "coords_{domain}_{shape}.nc"),
+        )
+
+        maybe_unstacked = xs.utils.maybe_unstack(
+            out, dim="loc1", coords=str(tmp_path / "coords_{domain}_{shape}.nc")
+        )
+        assert maybe_unstacked.equals(out)
+        # Call through clean_up to test the whole pipeline
+        maybe_unstack_dict = {
+            "dim": "loc1",
+            "coords": str(tmp_path / "coords_{domain}_{shape}.nc"),
+            "stack_drop_nans": True,
+        }
+        maybe_unstacked = xs.utils.clean_up(out, maybe_unstack_dict=maybe_unstack_dict)
+        assert maybe_unstacked.equals(ds)
+        maybe_unstacked = xs.utils.maybe_unstack(
+            out,
+            dim="loc1",
+            coords=str(tmp_path / "coords_{domain}_{shape}.nc"),
+            rechunk={"lon": -1, "lat": 2},
+            stack_drop_nans=True,
+        )
+        assert dict(maybe_unstacked.chunks) == {
+            "time": (20,),
+            "lat": (2, 2, 2, 2, 2),
+            "lon": (10,),
+        }
+
+
+class TestVariablesUnits:
+    def test_variables_same(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="tas",
+            start="2001-01-01",
+            freq="MS",
+            as_dataset=True,
+        )
+        out = xs.clean_up(ds, variables_and_units={"tas": "degK"})
+        assert out.tas.attrs["units"] == "degK"
+        np.testing.assert_array_equal(out.tas, ds.tas)
+
+    def test_variables_2(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="tas",
+            start="2001-01-01",
+            freq="MS",
+            as_dataset=True,
+        )
+        ds["pr"] = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="pr",
+            start="2001-01-01",
+            freq="MS",
+        )
+        out = xs.clean_up(ds, variables_and_units={"tas": "degK"})
+        assert out.tas.attrs["units"] == "degK"
+        assert out.pr.attrs["units"] == "kg m-2 s-1"
+
+    def test_variables_sametime(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="pr",
+            start="2001-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        out = xs.clean_up(ds, variables_and_units={"pr": "mm/day"})
+        assert out.pr.attrs["units"] == "mm d-1"
+        np.testing.assert_array_almost_equal(out.pr, ds.pr * 86400)
+
+    def test_variables_amount2rate(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="pr",
+            start="2001-01-01",
+            freq="D",
+            units="mm",
+            as_dataset=True,
+        )
+        out = xs.clean_up(ds, variables_and_units={"pr": "mm/day"})
+        assert out.pr.attrs["units"] == "mm d-1"
+        np.testing.assert_array_almost_equal(out.pr, ds.pr)
+
+    def test_variables_rate2amount(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="pr",
+            start="2001-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        out = xs.clean_up(ds, variables_and_units={"pr": "mm"})
+        assert out.pr.attrs["units"] == "mm"
+        np.testing.assert_array_almost_equal(out.pr, ds.pr * 86400)
+
+    def test_variables_error(self):
+        ds = timeseries(
+            np.tile(np.arange(1, 13), 3),
+            variable="pr",
+            start="2001-01-01",
+            freq="D",
+            units="mm s-2",
+            as_dataset=True,
+        )
+        with pytest.raises(ValueError, match="No known transformation"):
+            xs.clean_up(ds, variables_and_units={"pr": "mm"})
+
+
+class TestCalendar:
+    def test_normal(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+
+        out = xs.clean_up(ds, convert_calendar_kwargs={"calendar": "noleap"})
+        assert isinstance(out.time.values[0], cftime.DatetimeNoLeap)
+        assert len(out.time) == 365 * 4
+
+    def test_360(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+
+        out = xs.clean_up(ds, convert_calendar_kwargs={"calendar": "360_day"})
+        assert isinstance(out.time.values[0], cftime.Datetime360Day)
+        assert len(out.time) == 360 * 4
+        assert len(out.time.sel(time="2000-02-30")) == 1
+
+    def test_missing_by_var(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds["pr"] = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="pr",
+            start="2000-01-01",
+            freq="D",
+        )
+        ds = xs.clean_up(ds, convert_calendar_kwargs={"calendar": "noleap"})
+        missing_by_vars = {"tas": "interpolate", "pr": 9999}
+
+        out = xs.clean_up(
+            ds,
+            convert_calendar_kwargs={"calendar": "standard"},
+            missing_by_var=missing_by_vars,
+        )
+        assert out.tas.isnull().sum() == 0
+        np.testing.assert_array_equal(out.tas.sel(time="2000-02-29"), 60)
+        assert out.pr.isnull().sum() == 0
+        np.testing.assert_array_equal(out.pr.sel(time="2000-02-29"), 9999)
+
+    def test_missing_by_var_error(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds["pr"] = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="pr",
+            start="2000-01-01",
+            freq="D",
+        )
+        missing_by_vars = {"pr": 9999}
+        with pytest.raises(ValueError, match="All variables must be"):
+            xs.clean_up(
+                ds,
+                convert_calendar_kwargs={"calendar": "standard"},
+                missing_by_var=missing_by_vars,
+            )
+
+
+def test_round():
+    ds = timeseries(
+        np.arange(1, 365 * 4 + 2) / 1234,
+        variable="tas",
+        start="2000-01-01",
+        freq="D",
+        as_dataset=True,
+    )
+    ds["pr"] = timeseries(
+        np.arange(1, 365 * 4 + 2) / 1234,
+        variable="pr",
+        start="2000-01-01",
+        freq="D",
+    )
+    out = xs.clean_up(ds, round_var={"tas": 6, "pr": 1})
+    np.testing.assert_array_equal(out.tas.isel(time=0), 0.000810)
+    np.testing.assert_array_equal(out.pr.isel(time=0), 0.0)
+    assert "Rounded 'pr' to 1 decimal" in out["pr"].attrs["history"]
+
+
+class TestAttrs:
+    def test_common(self):
+        ds1 = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+
+        ds2 = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds2.attrs = {
+            "foo": "bar",
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+            "cat:mip_era": "CMIP6",
+        }
+        ds3 = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds3.attrs = {
+            "foo": "bar",
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CanESM5",
+            "cat:mip_era": "CMIP6",
+        }
+
+        # Nothing in common between ds1 and the other datasets
+        ds1.attrs = {"bar": "foo"}
+        out = xs.clean_up(ds1, common_attrs_only=[ds2, ds3])
+        assert out.attrs == {}
+
+        ds1.attrs = ds2.attrs
+        out = xs.clean_up(ds1, common_attrs_only=[ds2, ds3])
+        assert all(
+            k in out.attrs
+            for k in ["foo", "cat:type", "cat:variable", "cat:mip_era", "cat:id"]
+        )
+        assert out.attrs["cat:id"] == "CMIP6"
+
+        del ds1.attrs["cat:mip_era"]
+        out = xs.clean_up(ds1, common_attrs_only={"a": ds2, "b": ds3})
+        assert all(
+            k in out.attrs for k in ["foo", "cat:type", "cat:variable", "cat:id"]
+        )
+        assert out.attrs["cat:id"] == ""
+
+    def test_common_open(self):
+        ds1 = xr.open_dataset(
+            Path(__file__).parent.parent
+            / "docs"
+            / "notebooks"
+            / "samples"
+            / "tutorial"
+            / "ScenarioMIP"
+            / "example-region"
+            / "NCC"
+            / "NorESM2-MM"
+            / "ssp126"
+            / "r1i1p1f1"
+            / "day"
+            / "ScenarioMIP_NCC_NorESM2-MM_ssp126_r1i1p1f1_gn_raw.nc"
+        )
+        ds1.attrs["cat:id"] = "SomeID"
+        ds2 = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "notebooks"
+            / "samples"
+            / "tutorial"
+            / "ScenarioMIP"
+            / "example-region"
+            / "NCC"
+            / "NorESM2-MM"
+            / "ssp245"
+            / "r1i1p1f1"
+            / "day"
+            / "ScenarioMIP_NCC_NorESM2-MM_ssp245_r1i1p1f1_gn_raw.nc"
+        )
+        ds3 = (
+            Path(__file__).parent.parent
+            / "docs"
+            / "notebooks"
+            / "samples"
+            / "tutorial"
+            / "ScenarioMIP"
+            / "example-region"
+            / "NCC"
+            / "NorESM2-MM"
+            / "ssp585"
+            / "r1i1p1f1"
+            / "day"
+            / "ScenarioMIP_NCC_NorESM2-MM_ssp585_r1i1p1f1_gn_raw.nc"
+        )
+
+        out = xs.clean_up(ds1, common_attrs_only=[ds2, ds3])
+        assert (
+            out.attrs["comment"]
+            == "This is a test file created for the xscen tutorial. This file is not a real CMIP6 file."
+        )
+        assert out.attrs.get("cat:id") is None
+
+    def test_to_level(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        out = xs.clean_up(ds, to_level="cat")
+        assert out.attrs["cat:processing_level"] == "cat"
+
+    def test_remove(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds.attrs = {
+            "foo": "bar",
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+            "bacat:mip_era": "CMIP6",
+        }
+        out = xs.clean_up(
+            ds, attrs_to_remove={"tas": ["units"], "global": [".*cat.*", "foo"]}
+        )
+        assert "units" in ds.tas.attrs
+        assert "units" not in out.tas.attrs
+        assert out.attrs == {}
+        out2 = xs.clean_up(ds, attrs_to_remove={"tas": ["units"], "global": ["cat.*"]})
+        assert out2.attrs == {"foo": "bar", "bacat:mip_era": "CMIP6"}
+
+    def test_remove_except(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds.attrs = {
+            "foo": "bar",
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+            "bacat:mip_era": "CMIP6",
+        }
+        out = xs.clean_up(
+            ds, remove_all_attrs_except={"tas": ["units"], "global": [".*cat.*"]}
+        )
+        assert out.tas.attrs == {"units": "K"}
+        assert out.attrs == {
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+            "bacat:mip_era": "CMIP6",
+        }
+        out2 = xs.clean_up(ds, remove_all_attrs_except={"global": ["cat.*"]})
+        assert len(out2.tas.attrs) == 4
+        assert out2.attrs == {
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+        }
+
+    def test_add_attr(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        out = xs.clean_up(
+            ds,
+            add_attrs={"tas": {"foo": "bar"}, "global": {"foo2": "electric boogaloo"}},
+        )
+        assert out.tas.attrs["foo"] == "bar"
+        assert out.attrs["foo2"] == "electric boogaloo"
+
+    @pytest.mark.parametrize(
+        "change_prefix", ["dog", {"cat": "dog:"}, {"cat:": "dog:", "bacat": "badog"}]
+    )
+    def test_change_prefix(self, change_prefix):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        ds.attrs = {
+            "foo": "bar",
+            "cat:type": "simulation",
+            "cat:variable": ("tas",),
+            "cat:source": "CNRM-CM6",
+            "bacat:mip_era": "CMIP6",
+        }
+        out = xs.clean_up(ds, change_attr_prefix=change_prefix)
+        if isinstance(change_prefix, str) or len(change_prefix) == 1:
+            assert out.attrs == {
+                "foo": "bar",
+                "dog:type": "simulation",
+                "dog:variable": ("tas",),
+                "dog:source": "CNRM-CM6",
+                "bacat:mip_era": "CMIP6",
+            }
+        else:
+            assert out.attrs == {
+                "foo": "bar",
+                "dog:type": "simulation",
+                "dog:variable": ("tas",),
+                "dog:source": "CNRM-CM6",
+                "badog:mip_era": "CMIP6",
+            }
+
+
+class TestPublish:
+    @pytest.mark.parametrize("fmt", ["md", "rst"])
+    def test_normal(self, fmt):
+        out = xs.utils.publish_release_notes(fmt)
+        if fmt == "md":
+            assert out.startswith("# Changelog\n\n")
+            assert "[PR/413](https://github.com/Ouranosinc/xscen/pull/413)" in out
+        elif fmt == "rst":
+            assert out.startswith("=========\nChangelog\n=========\n\n")
+            assert "`PR/413 <https://github.com/Ouranosinc/xscen/pull/\\>`_" in out
+
+    def test_error(self):
+        with pytest.raises(FileNotFoundError):
+            xs.utils.publish_release_notes("md", changes="foo")
+        with pytest.raises(NotImplementedError):
+            xs.utils.publish_release_notes("foo")
+
+    def test_file(self, tmpdir):
+        xs.utils.publish_release_notes("md", file=tmpdir / "foo.md")
+        with open(tmpdir / "foo.md") as f:
+            assert f.read().startswith("# Changelog\n\n")
+
+
+class TestUnstackDates:
+    @pytest.mark.parametrize(
+        "freq", ["MS", "2MS", "3MS", "QS-DEC", "QS", "2QS", "YS", "YS-DEC", "4YS"]
+    )
+    def test_normal(self, freq):
+        ds = timeseries(
+            np.arange(1, 35),
+            variable="tas",
+            start="2000-01-01",
+            freq=freq,
+            as_dataset=True,
+        )
+        out = xs.utils.unstack_dates(ds)
+        np.testing.assert_array_equal(
+            out.time,
+            pd.date_range(
+                "2000-01-01",
+                periods=len(np.unique(ds.time.dt.year)),
+                freq="YS" if freq != "4YS" else "4YS",
+            ),
+        )
+        if freq == "MS":
+            np.testing.assert_array_equal(
+                out.month,
+                [
+                    "JAN",
+                    "FEB",
+                    "MAR",
+                    "APR",
+                    "MAY",
+                    "JUN",
+                    "JUL",
+                    "AUG",
+                    "SEP",
+                    "OCT",
+                    "NOV",
+                    "DEC",
+                ],
+            )
+        elif "M" in freq:
+            assert len(out.season) == 12 / int(freq[0])
+            np.testing.assert_array_equal(
+                out.season[0], ["JF"] if freq == "2MS" else ["JFM"]
+            )
+        elif "QS" in freq:
+            assert len(out.season) == 4 if freq != "2QS" else 2
+            np.testing.assert_array_equal(
+                out.season[0],
+                (
+                    ["MAM"]
+                    if freq == "QS-DEC"
+                    else ["JFM"] if freq == "QS" else ["JFMAMJ"]
+                ),
+            )
+        else:
+            assert len(out.season) == 1
+            np.testing.assert_array_equal(
+                out.season[0], [f"{freq.replace('YS', 'annual')}"]
+            )
+
+    @pytest.mark.parametrize("freq", ["MS", "QS", "YS"])
+    def test_seasons(self, freq):
+        ds = timeseries(
+            np.arange(1, 35),
+            variable="tas",
+            start="2000-01-01",
+            freq=freq,
+            as_dataset=True,
+        )
+        seasons = {
+            1: "january",
+            2: "february",
+            3: "march",
+            4: "april",
+            5: "may",
+            6: "june",
+            7: "july",
+            8: "august",
+            9: "september",
+            10: "october",
+            11: "november",
+            12: "december",
+        }
+        out = xs.utils.unstack_dates(ds, seasons=seasons)
+        if freq == "MS":
+            np.testing.assert_array_equal(
+                out.month,
+                [
+                    "january",
+                    "february",
+                    "march",
+                    "april",
+                    "may",
+                    "june",
+                    "july",
+                    "august",
+                    "september",
+                    "october",
+                    "november",
+                    "december",
+                ],
+            )
+        elif freq == "QS":
+            np.testing.assert_array_equal(
+                out.season, ["january", "april", "july", "october"]
+            )
+        elif freq == "YS":
+            np.testing.assert_array_equal(out.season, ["january"])
+
+    @pytest.mark.parametrize("freq", ["2MS", "QS-DEC", "YS-DEC"])
+    def test_winter(self, freq):
+        ds = timeseries(
+            np.arange(1, 35),
+            variable="tas",
+            start="2000-12-01",
+            freq=freq,
+            as_dataset=True,
+        )
+        out = xs.utils.unstack_dates(ds)
+        assert pd.Timestamp(str(out.time[0].values).split("T")[0]) == pd.Timestamp(
+            "2000-01-01"
+        )
+        out = xs.utils.unstack_dates(ds, winter_starts_year=True)
+        assert pd.Timestamp(str(out.time[0].values).split("T")[0]) == pd.Timestamp(
+            "2001-01-01"
+        )
+
+    def test_coords(self):
+        freq = "MS"
+        ds = timeseries(
+            np.arange(1, 35),
+            variable="tas",
+            start="2000-01-01",
+            freq=freq,
+        )
+        ds["horizon"] = xr.DataArray(
+            np.array(["2001-2009"] * len(ds.time)),
+            dims="time",
+            coords={"time": ds.time},
+        )
+        ds = ds.assign_coords({"horizon": ds.horizon})
+        out = xs.utils.unstack_dates(ds)
+        assert all(k in out["horizon"].dims for k in ["time", "month"])
+
+    def test_dask(self):
+        freq = "MS"
+        ds = timeseries(
+            dask.array.from_array(np.arange(1, 35), chunks=(10,)),
+            variable="tas",
+            start="2000-01-01",
+            freq=freq,
+        )
+        out = xs.utils.unstack_dates(ds)
+        assert isinstance(out.data, dask.array.Array)
+        assert "month" in out.dims
+
+    def test_errors(self):
+        ds = timeseries(
+            np.arange(1, 365 * 4 + 2),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            as_dataset=True,
+        )
+        with pytest.raises(ValueError, match="Only monthly frequencies"):
+            xs.utils.unstack_dates(ds)
+        ds = ds.where(ds.time.dt.day != 1, drop=True)
+        with pytest.raises(
+            ValueError, match="The data must have a clean time coordinate."
+        ):
+            xs.utils.unstack_dates(ds)
+
+        ds = timeseries(
+            np.arange(1, 13),
+            variable="tas",
+            start="2000-01-01",
+            freq="7MS",
+            as_dataset=True,
+        )
+        with pytest.raises(
+            ValueError, match="Only periods that divide the year evenly are supported."
+        ):
+            xs.utils.unstack_dates(ds)
+
+
+def test_show_version(tmpdir):
+    xs.utils.show_versions(file=tmpdir / "versions.txt")
+    with open(tmpdir / "versions.txt") as f:
+        out = f.read()
+    assert "xscen" in out
+    assert "xclim" in out
+    assert "xarray" in out
+    assert "numpy" in out
+    assert "pandas" in out
+    assert "dask" in out
+    assert "cftime" in out
+    assert "netCDF4" in out
+
+
+class TestEnsureTime:
+    def test_xrfreq_ok(self):
+        ds = timeseries(
+            np.arange(1, 360),
+            variable="tas",
+            start="2000-01-01T12:00:00",
+            freq="D",
+            as_dataset=True,
+        )
+        out = xs.utils.ensure_correct_time(ds, "D")
+        assert np.all(out.time.dt.hour == 0)
+
+    def test_xrfreq_bad(self):
+        ds = timeseries(
+            np.arange(1, 360),
+            variable="tas",
+            start="2000-01-01T12:00:00",
+            freq="D",
+            as_dataset=True,
+        )
+        # Add random small number of seconds to the time
+        ds["time"] = ds.time + (np.random.rand(len(ds.time)) * 10).astype(
+            "timedelta64[s]"
+        )
+        out = xs.utils.ensure_correct_time(ds, "D")
+        assert np.all(out.time.dt.hour == 0)
+        assert np.all(out.time.dt.second == 0)
+
+    def test_xrfreq_error(self):
+        ds = timeseries(
+            np.arange(1, 360),
+            variable="tas",
+            start="2000-01-01T12:00:00",
+            freq="D",
+            as_dataset=True,
+        )
+        # Add random small number of seconds to the time
+        rng = np.random.default_rng(0)
+        ds["time"] = ds.time + (rng.random(len(ds.time)) * 24).astype("timedelta64[h]")
+        with pytest.raises(
+            ValueError,
+            match="Dataset is labelled as having a sampling frequency of D, but some periods have more than one data point.",
+        ):
+            xs.utils.ensure_correct_time(ds, "D")
+        ds = timeseries(
+            np.arange(1, 360),
+            variable="tas",
+            start="2000-01-01T12:00:00",
+            freq="D",
+            as_dataset=True,
+        )
+        # Remove some time points
+        ds = ds.where(ds.time.dt.day % 2 == 0, drop=True)
+        with pytest.raises(
+            ValueError,
+            match="The resampling count contains NaNs or 0s. There might be some missing data.",
+        ):
+            xs.utils.ensure_correct_time(ds, "D")
+
+
+class TestStandardPeriod:
+    @pytest.mark.parametrize(
+        "period", [[1981, 2010], [[1981, 2010]], ["1981", "2010"], [["1981", "2010"]]]
+    )
+    def test_normal(self, period):
+        out = xs.utils.standardize_periods(period, multiple=True)
+        assert out == [["1981", "2010"]]
+
+        out = xs.utils.standardize_periods(period, multiple=False)
+        assert out == ["1981", "2010"]
+
+    def test_error(self):
+        assert xs.utils.standardize_periods(None) is None
+        with pytest.raises(ValueError, match="should be comprised of two elements"):
+            xs.utils.standardize_periods(["1981-2010"])
+        with pytest.raises(ValueError, match="should be in chronological order,"):
+            xs.utils.standardize_periods(["2010", "1981"])
+        with pytest.raises(ValueError, match="should be a single instance"):
+            xs.utils.standardize_periods(
+                [["1981", "2010"], ["1981", "2010"]], multiple=False
+            )
+
+
+def test_sort_seasons():
+    seasons = pd.Index(["JJA", "DJF", "SON", "MAM"])
+    out = xs.utils.season_sort_key(seasons, name="season")
+    np.testing.assert_array_equal(out, [6, 0, 9, 3])
+
+    seasons = pd.Index(["JFM", "JAS", "OND", "AMJ"])
+    out = xs.utils.season_sort_key(seasons, name="season")
+    np.testing.assert_array_equal(out, [1, 7, 10, 4])
+
+    seasons = pd.Index(["FEB", "JAN", "MAR", "DEC"])
+    out = xs.utils.season_sort_key(seasons, name="month")
+    np.testing.assert_array_equal(out, [1, 0, 2, 11])
+
+    # Invalid returns the original object
+    seasons = pd.Index(["FEB", "DEC", "foo"])
+    out = xs.utils.season_sort_key(seasons, name="month")
+    np.testing.assert_array_equal(out, seasons)
+
+
+def test_xrfreq_to_timedelta():
+    assert xs.utils.xrfreq_to_timedelta("D") == pd.Timedelta(1, "D")
+    assert xs.utils.xrfreq_to_timedelta("QS-DEC") == pd.Timedelta(90, "D")
+    assert xs.utils.xrfreq_to_timedelta("YS") == pd.Timedelta(365, "D")
+    assert xs.utils.xrfreq_to_timedelta("2QS") == pd.Timedelta(180, "D")
+    with pytest.raises(ValueError, match="Invalid frequency"):
+        xs.utils.xrfreq_to_timedelta("foo")
+
+
+def test_ensure_new_xrfreq():
+    assert xs.utils.ensure_new_xrfreq("2M") == "2ME"
+    assert xs.utils.ensure_new_xrfreq("2Q-DEC") == "2QE-DEC"
+    assert xs.utils.ensure_new_xrfreq("AS-JUL") == "YS-JUL"
+    assert xs.utils.ensure_new_xrfreq("A-JUL") == "YE-JUL"
+    assert xs.utils.ensure_new_xrfreq("Y-JUL") == "YE-JUL"
+    assert xs.utils.ensure_new_xrfreq("A") == "YE"
+    assert xs.utils.ensure_new_xrfreq("Y") == "YE"
+    assert xs.utils.ensure_new_xrfreq("3H") == "3h"
+    assert xs.utils.ensure_new_xrfreq("3T") == "3min"
+    assert xs.utils.ensure_new_xrfreq("3S") == "3s"
+    assert xs.utils.ensure_new_xrfreq("3L") == "3ms"
+    assert xs.utils.ensure_new_xrfreq("3U") == "3us"
+
+    # Errors
+    assert xs.utils.ensure_new_xrfreq(3) == 3
+    assert xs.utils.ensure_new_xrfreq("foo") == "foo"
+
+
+def test_xarray_defaults():
+    kwargs = {
+        "chunks": {"time": 10},
+        "foo": "bar",
+        "xr_open_kwargs": {"decode_times": False},
+        "xr_combine_kwargs": {"combine_attrs": "drop"},
+    }
+    out = xs.utils._xarray_defaults(**kwargs)
+    assert out == {
+        "chunks": {"time": 10},
+        "foo": "bar",
+        "xarray_open_kwargs": {"decode_times": False, "chunks": {}},
+        "xarray_combine_by_coords_kwargs": {
+            "combine_attrs": "drop",
+            "data_vars": "minimal",
+        },
+    }


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Adds tests for all functions located in `utils.py`. With the exception of a few lines impossible to test, everything should be covered.
* The `mask` argument in `stack_drop_nans` can now be a list of dimensions. In that case, a `dropna(how='all')` operation will be used to create the mask on-the-fly.
* `convert_calendar` in `xs.utils.clean_up` now uses `xarray` instead of `xclim`.
* `attrs_to_remove` and `remove_all_attrs_except` in `xs.utils.clean_up` now use real regex.
* Smaller changes:
  * `minimum_calendar` now accepts a list as input.
  * More calendars are recognized in `translate_time_chunk`
  * Multiple entries can now be given for `change_attr_prefix` in `xs.utils.clean_up`.
  * `new_dim` in `unstack_dates` is now None by default and changes depending on the frequency. It becomes `month` if the data is exactly monthly, and keep the old default of `season` otherwise.
  * Updated the list of libraries in `show_versions` to reflect our current environment.

* Bug fixes:
  * `maybe_unstack` now works if the dimension name is not the default.
  * `xs.utils.clean_up` now does not also modify the original dataset.
  * `unstack_dates` now works correctly for yearly datasets when `winter_starts_year=True`.
  * `unstack_dates` now works correctly for multi-year frequencies.


### Does this PR introduce a breaking change?

* `convert_calendar` in `xs.utils.clean_up` now uses `xarray` instead of `xclim`. Keywords aren't compatible between the two, but given that `xclim` will abandon its function, no backwards compatibility was sought.
* `attrs_to_remove` and `remove_all_attrs_except` in `xs.utils.clean_up` now use real regex. It should not be too breaking since a `fullmatch()` is used, but `*` is now `.*`.

### Other information:

There are 2 lines in `unstack_fill_nan` that I simply don't understand... They will be covered next week when I can talk to the author.