### PR TITLE
Adapt to xclim 0.55 - Fix Upstream CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version: [ "3.10", "3.11", "3.12" ] # "3.13"
-        xclim-min-version: [ "0.53.2" ]
+        xclim-min-version: [ "0.55" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -62,7 +62,7 @@ jobs:
           echo "micromamba: $(micromamba --version)"
       - name: Install upstream dependencies
         run: |
-          python -m pip install -r requirements_upstream.txt
+          python -m pip install -r CI/requirements_upstream.txt
       - name: Install xscen
         run: |
           make translate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changelog
 
 v0.12.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * `xscen` now uses `flit` as its build-engine and no longer uses `setuptools`, `setuptools-scm`, or `wheel`. (:pull:`519`).
+* Update to xclim 0.55 (:pull:`532`).
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/notebooks/1_catalog.ipynb
+++ b/docs/notebooks/1_catalog.ipynb
@@ -1154,7 +1154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/2_getting_started.ipynb
+++ b/docs/notebooks/2_getting_started.ipynb
@@ -794,7 +794,7 @@
    "source": [
     "xclim_train_args = {\"kind\": \"+\", \"nquantiles\": 50}\n",
     "\n",
-    "xclim_adjust_args = {\"detrend\": 3, \"interp\": \"linear\", \"extrapolation\": \"constant\"}"
+    "xclim_adjust_args = {\"detrend\": 3, \"extrapolation\": \"constant\"}"
    ]
   },
   {
@@ -1476,7 +1476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,8 +31,8 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0, <2024.10.0 # FIXME: 2024.10.0 breaks rechunker with zarr, https://github.com/pangeo-data/rechunker/issues/154
-  - xclim >=0.53.2, <0.55
-  - xesmf >=0.7, <0.8.8  # FIXME: 0.8.8 currently creates segfaults on ReadTheDocs.
+  - xclim >=0.55, <0.56
+  - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3.0 # FIXME: xarray is compatible with zarr 3.0 from 2025.01.1, but we pin xarray below that version
   # Opt
   - nc-time-axis >=1.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -31,8 +31,8 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0, <2024.10.0 # FIXME: 2024.10.0 breaks rechunker with zarr
-  - xclim >=0.53.2, <0.55
-  - xesmf >=0.7, <0.8.8  # FIXME: 0.8.8 currently creates segfaults on ReadTheDocs.
+  - xclim >=0.55, <0.56
+  - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3.0 # FIXME: xarray is compatible with zarr 3.0 from 2025.01.1, but we pin xarray below that version
   # To install from source
   - flit >=3.9,<4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  # "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Atmospheric Science"
 ]
@@ -62,7 +62,7 @@ dependencies = [
   "sparse",
   "toolz",
   "xarray >=2023.11.0, !=2024.6.0, <2024.10.0", # FIXME: 2024.10.0 breaks rechunker with zarr
-  "xclim >=0.53.2, <0.55",
+  "xclim >=0.55, <0.56",
   "zarr >=2.13, <3.0" # FIXME: xarray is compatible with zarr 3.0 from 2025.01.1, but we pin xarray below that version"
 ]
 
@@ -108,7 +108,7 @@ docs = [
   "sphinxcontrib-napoleon"
 ]
 extra = [
-  "xesmf >=0.7,<0.8.8" # FIXME: 0.8.8 currently creates segfaults on ReadTheDocs.
+  "xesmf >=0.7, !=0.8.8"
 ]
 all = ["xscen[dev]", "xscen[docs]", "xscen[extra]"]
 

--- a/src/xscen/catutils.py
+++ b/src/xscen/catutils.py
@@ -656,8 +656,8 @@ def parse_directory(  # noqa: C901
 
     if read_file_groups:  # Read fields from file, but only one per group.
         for group_cols, parse_cols in read_from_file:
-            df = (
-                df.groupby(group_cols)
+            df = (  # column indexing avoids a deprecation where cols in group_cols are not sent to apply
+                df.groupby(group_cols)[df.columns]
                 .apply(
                     _parse_first_ds,
                     cols=parse_cols,

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -513,14 +513,10 @@ def resample(  # noqa: C901
         missing_note = f", {action} incomplete periods "
     elif isinstance(missing, dict):
         missmeth = missing.pop("method")
-        complete = ~xc.core.missing.MISSING_METHODS[missmeth](
-            da, target_frequency, initial_frequency
-        )(**missing)
-        funcstr = xc.core.formatting.gen_call_string(
-            f"xclim.core.missing_{missmeth}", **missing
-        )
+        miss = xc.core.missing.MISSING_METHODS[missmeth](**missing)
+        complete = ~miss(da, target_frequency, initial_frequency)
         missing = "mask"
-        missing_note = f", masking incomplete periods according to {funcstr} "
+        missing_note = f", masking incomplete periods according to {miss} "
     if missing in {"mask", "drop"}:
         out = out.where(complete, drop=(missing == "drop"))
 

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -359,7 +359,7 @@ def resample(  # noqa: C901
     """
     var_name = da.name
 
-    initial_frequency = xr.infer_freq(da.time.dt.round("T")) or "undetected"
+    initial_frequency = xr.infer_freq(da.time.dt.round("min")) or "undetected"
     if initial_frequency == "undetected":
         warnings.warn(
             "Could not infer the frequency of the dataset. Be aware that this might result in erroneous manipulations."
@@ -1198,7 +1198,7 @@ def _wl_find_column(tas, model):
         logger.info(
             "More than one simulation of the database fits the dataset metadata. Choosing the first one."
         )
-    tas_sel = tas.isel(simulation=candidates.argmax())
+    tas_sel = tas.isel(simulation=candidates.argmax("simulation"))
     return tas_sel
 
 

--- a/src/xscen/spatial.py
+++ b/src/xscen/spatial.py
@@ -50,6 +50,8 @@ def creep_weights(mask: xr.DataArray, n: int = 1, mode: str = "clip") -> xr.Data
     DataArray
        Weights. The dot product must be taken over the last N dimensions.
     """
+    if mode not in ["clip", "wrap"]:
+        raise ValueError("mode must be either 'clip' or 'wrap'")
     da = mask
     mask = da.values
     neighbors = np.array(
@@ -71,8 +73,6 @@ def creep_weights(mask: xr.DataArray, n: int = 1, mode: str = "clip") -> xr.Data
                 )
             elif mode == "wrap":
                 neigh_idx = np.unravel_index(neigh_idx_1d, mask.shape, order="C")
-            else:
-                raise ValueError("mode must be either 'clip' or 'wrap'")
             neigh = mask[neigh_idx]
             N = (neigh).sum()
             if N > 0:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -957,7 +957,7 @@ class TestClimatologicalOp:
         )
 
         assert (out.tas_clim_mean.values == np.tile(np.arange(1, o + 1), (5, 1))).all()
-        assert out.dims == {"horizon": 5} | freq[xrfreq]
+        assert out.sizes == {"horizon": 5} | freq[xrfreq]
         assert out.time.dims == ("horizon",) + (
             (next(iter(freq[xrfreq])),) if freq[xrfreq] else ()
         )

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -248,7 +248,7 @@ def test_parse_from_zarr(tmp_path):
 def test_parse_from_nc(tmp_path):
     # Real ds
     ds = xr.tutorial.open_dataset("air_temperature")
-    ds.to_netcdf(tmp_path / "air.nc")
+    ds.to_netcdf(tmp_path / "air.nc", encoding={"air": {"dtype": "float32"}})
     info = cu.parse_from_ds(
         tmp_path / "air.nc",
         names=["frequency", "source", "variable"],

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -400,7 +400,7 @@ class TestPropertiesMeasures:
         )
         print(m2)
         print(m2["maximum_length_of_warm_spell"].values)
-        assert m1.dims == {}
+        assert m1.sizes == {}
         np.testing.assert_allclose(m2["maximum_length_of_warm_spell"].values, 0)
 
     def test_measures_heatmap(self):

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -1056,7 +1056,7 @@ class TestEnsemblePartition:
             rename_dict={"source": "new-name"},
         )
 
-        assert ds.dims == {"time": 730, "scenario": 4, "new-name": 1}
+        assert ds.sizes == {"time": 730, "scenario": 4, "new-name": 1}
         assert ds.attrs["cat:processing_level"] == "partition-ensemble"
 
         # test regrid
@@ -1070,7 +1070,7 @@ class TestEnsemblePartition:
             to_level="test",
         )
 
-        assert ds.dims == {
+        assert ds.sizes == {
             "scenario": 4,
             "model": 1,
             "time": 730,
@@ -1114,7 +1114,7 @@ class TestEnsemblePartition:
         )
 
         assert "NCC_NorESM2-MM_r1i1p1f1" in ds.model.values
-        assert ds.dims == {"time": 730, "scenario": 4, "model": 2}
+        assert ds.sizes == {"time": 730, "scenario": 4, "model": 2}
 
 
 class TestReduceEnsemble:

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -11,7 +11,7 @@ class TestScripting:
         np.tile(np.arange(1, 2), 50),
         variable="tas",
         start="2000-01-01",
-        freq="AS-JAN",
+        freq="YS-JAN",
         as_dataset=True,
     )
     ds.attrs = {


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Fix the usage of `Missing` objects from xclim
* Raise the minimum version of xclim to 0.55, max < 0.56.
* Updates the pin on xESMF (the issue is fixed in the master, so 0.8.9 will be ok)
* Fix the Upstream CI :  #519 moved the requirements file without updating the workflow!
* Squash some warnings. On my side, the "squash [...]" commit removed 97 warnings from `test_extract.py` and 17 from other places. I think most warnings come from `intake_esm`.

### Does this PR introduce a breaking change?
No.

### Other information:
