### PR TITLE
Use xclim `convert_units_to` in ``xs.train``  and ``xs.adjust``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Éric Dupuis (:user:`coxipi`).
 
 Bug fixes
 ^^^^^^^^^
-* Patch ``xsdba.units.convert_units_to`` with ``xclim.core.units.convert_units_to`` with `context="infer"` locally in ``xs.train`` and ``xs.adjust`` instead of using ``xc.core.settings.context``.
+* Patch ``xsdba.units.convert_units_to`` with ``xclim.core.units.convert_units_to`` with `context="infer"` locally in ``xs.train`` and ``xs.adjust`` instead of using ``xc.core.settings.context``. (:pull:`552`).
 
 
 v0.12.0 (2025-03-10)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+Contributors to this version: Éric Dupuis (:user:`coxipi`).
+
+Bug fixes
+^^^^^^^^^
+* Patch ``xsdba.units.convert_units_to`` with ``xclim.core.units.convert_units_to`` with `context="infer"` locally in ``xs.train`` and ``xs.adjust`` instead of using ``xc.core.settings.context``.
+
+
 v0.12.0 (2025-03-10)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Sarah Gammon (:user:`SarahG-579462`), Éric Dupuis (:user:`coxipi`).

--- a/src/xscen/biasadjust.py
+++ b/src/xscen/biasadjust.py
@@ -60,15 +60,13 @@ def _convert_units_to_infer(source, target):
 
 @contextmanager
 def xclim_convert_units_to():
-    module = xsdba.units
-    attr_name = "convert_units_to"
-    new_value = _convert_units_to_infer
-    original_value = getattr(module, attr_name)
-    setattr(module, attr_name, new_value)
+    original_function = xsdba.units.convert_units_to
+    new_function = _convert_units_to_infer
     try:
+        xsdba.units.convert_units_to = new_function
         yield
     finally:
-        setattr(module, attr_name, original_value)
+        xsdba.units.convert_units_to = original_function
 
 
 @parse_config

--- a/src/xscen/biasadjust.py
+++ b/src/xscen/biasadjust.py
@@ -2,7 +2,6 @@
 
 import logging
 import warnings
-from contextlib import contextmanager
 from copy import deepcopy
 
 import xarray as xr
@@ -11,7 +10,7 @@ import xsdba
 
 from .catutils import parse_from_ds
 from .config import parse_config
-from .utils import minimum_calendar, standardize_periods
+from .utils import minimum_calendar, standardize_periods, xclim_convert_units_to
 
 logger = logging.getLogger(__name__)
 xsdba.set_options(extra_output=False)
@@ -52,21 +51,6 @@ def _add_preprocessing_attr(scen, train_kwargs):
             "bias_adjustment"
         ] += ", ref and hist were prepared with " + " and ".join(preproc)
     return scen
-
-
-def _convert_units_to_infer(source, target):
-    return xc.core.units.convert_units_to(source, target, context="infer")
-
-
-@contextmanager
-def xclim_convert_units_to():
-    original_function = xsdba.units.convert_units_to
-    new_function = _convert_units_to_infer
-    try:
-        xsdba.units.convert_units_to = new_function
-        yield
-    finally:
-        xsdba.units.convert_units_to = original_function
 
 
 @parse_config

--- a/src/xscen/diagnostics.py
+++ b/src/xscen/diagnostics.py
@@ -30,6 +30,7 @@ from .utils import (
     standardize_periods,
     unstack_fill_nan,
     update_attr,
+    xclim_convert_units_to,
 )
 
 logger = logging.getLogger(__name__)
@@ -414,7 +415,8 @@ def properties_and_measures(  # noqa: C901
         # Make the call to xclim
         msg = f"{i} - Computing {iden}."
         logger.info(msg)
-        out = ind(ds=ds)
+        with xclim_convert_units_to():
+            out = ind(ds=ds)
         vname = out.name
         prop[vname] = out
 
@@ -423,9 +425,10 @@ def properties_and_measures(  # noqa: C901
 
         # calculate the measure if a reference dataset is given for the measure
         if dref_for_measure and vname in dref_for_measure:
-            meas[vname] = ind.get_measure()(
-                sim=prop[vname], ref=dref_for_measure[vname]
-            )
+            with xclim_convert_units_to():
+                meas[vname] = ind.get_measure()(
+                    sim=prop[vname], ref=dref_for_measure[vname]
+                )
             # create a merged long_name
             update_attr(
                 meas[vname],

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -850,7 +850,14 @@ def _convert_units_to_infer(source, target):
 
 @contextmanager
 def xclim_convert_units_to():
-    """Patch xsdba with xclim's units converter."""
+    """Patch xsdba with xclim's units converter.
+
+    Yields
+    ------
+    None
+        In this context, ``xsdba.units.convert_units_to`` is replaced with
+        ``xclim.core.units.convert_units_to`` with `context="infer"` activated.
+    """
     original_function = xsdba.units.convert_units_to
     new_function = _convert_units_to_infer
     try:

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -9,6 +9,7 @@ import re
 import warnings
 from collections import defaultdict
 from collections.abc import Sequence
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 from itertools import chain
@@ -20,6 +21,7 @@ import flox.xarray
 import numpy as np
 import pandas as pd
 import xarray as xr
+import xsdba
 from xarray.coding import cftime_offsets as cfoff
 from xclim.core import units
 from xclim.core.calendar import parse_offset
@@ -49,6 +51,7 @@ __all__ = [
     "unstack_dates",
     "unstack_fill_nan",
     "update_attr",
+    "xclim_convert_units_to",
     "xrfreq_to_timedelta",
 ]
 
@@ -839,6 +842,22 @@ def change_units(ds: xr.Dataset, variables_and_units: dict) -> xr.Dataset:
                 ds = ds.assign({v: ds[v].assign_attrs(units=variables_and_units[v])})
 
     return ds
+
+
+def _convert_units_to_infer(source, target):
+    return units.convert_units_to(source, target, context="infer")
+
+
+@contextmanager
+def xclim_convert_units_to():
+    """Patch xsdba with xclim's units converter."""
+    original_function = xsdba.units.convert_units_to
+    new_function = _convert_units_to_infer
+    try:
+        xsdba.units.convert_units_to = new_function
+        yield
+    finally:
+        xsdba.units.convert_units_to = original_function
 
 
 def clean_up(  # noqa: C901

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -316,7 +316,7 @@ class TestAdjust:
             dhistx = dhist.sel(time=slice("2001", "2003")).convert_calendar("noleap")
             dsimx = dsim.sel(time=slice("2001", "2006")).convert_calendar("noleap")
 
-            # xsdba is now climate agnostics, patch xclim's converter
+            # xsdba is now climate-agnostic, patch xclim's converter
             with xclim_convert_units_to():
                 dhist_ad, pth, dP0 = xsdba.processing.adapt_freq(
                     drefx["pr"], dhistx["pr"], group=group, thresh="1 mm d-1"

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -8,6 +8,8 @@ import xclim as xc
 import xsdba
 from xclim.testing.helpers import test_timeseries as timeseries
 
+from xscen.utils import xclim_convert_units_to
+
 # Copied from xarray/core/nputils.py
 # Can be removed once numpy 2.0+ is the oldest supported version
 try:
@@ -314,8 +316,8 @@ class TestAdjust:
             dhistx = dhist.sel(time=slice("2001", "2003")).convert_calendar("noleap")
             dsimx = dsim.sel(time=slice("2001", "2006")).convert_calendar("noleap")
 
-            # xsdba is now climate agnostics, hydro context must be specified
-            with xc.core.units.units.context("hydro"):
+            # xsdba is now climate agnostics, patch xclim's converter
+            with xclim_convert_units_to():
                 dhist_ad, pth, dP0 = xsdba.processing.adapt_freq(
                     drefx["pr"], dhistx["pr"], group=group, thresh="1 mm d-1"
                 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 import xclim as xc
+import xsdba
 from xclim.testing.helpers import test_timeseries as timeseries
 
 import xscen as xs
@@ -454,6 +455,13 @@ class TestStack:
         )
 
         assert maybe_unstacked.equals(unstacked)
+
+
+class TestXclimConvertUnitsContext:
+    def test_simple(self):
+        pr = timeseries([0, 1, 2], variable="pr", start="2001-01-01", units="mm d-1")
+        with xs.utils.xclim_convert_units_to():
+            xsdba.units.convert_units_to(pr, "kg m-2 s-1")
 
 
 class TestVariablesUnits:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Replace the `convert_units_to` implementation of `xsdba` by the one in `xclim` that allows to use `context="infer"`. Even if we fix the `xc.core.settings.context` thing, I think this solution might be preferred, as I understood in the discussions.

### Does this PR introduce a breaking change?

No

### Other information:

I like this method because I was a bit puzzled regarding how I would achieve automatic unit conversion with MBCn, but with this, this is almost free, I just have to revert some inconsequential changes in xsdba