### PR TITLE
fix default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+v0.13.0 (Unreleased)
+--------------------
+Contributors to this version:  Juliette Lavoie (:user:`juliettelavoie`)
+
+Bug fixes
+^^^^^^^^^
+* Fixed the default for ``xs.utils.maybe_unstack`` (:pull:`553`).
+
+
 v0.12.0 (2025-03-10)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Sarah Gammon (:user:`SarahG-579462`), Éric Dupuis (:user:`coxipi`).

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -645,7 +645,7 @@ def strip_cat_attrs(ds: xr.Dataset, prefix: str = "cat:"):
 @parse_config
 def maybe_unstack(
     ds: xr.Dataset,
-    dim: str | None = None,
+    dim: str | None = "loc",
     coords: str | None = None,
     rechunk: dict | None = None,
     stack_drop_nans: bool = False,


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

*  The default loc for `maybe_unstack` should be the same as for `stack` and `unstack`.

### Does this PR introduce a breaking change?
The code used to break if no dim was passed. Now, it works.

### Other information:
At first, there was just no dim in this function. It was added recently. Useful to reeach it from `clean_up`, but it was the wrong default.