### PR TITLE
Support latest xclim and xarray

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Added the ability to test `xESMF`-related functions with `tox / pip`. (:pull:`554`).
+* Updated the pins for `xclim`, `xarray`, `dask`, and `rechunker`. (:pull:`570`).
 
 v0.12.0 (2025-03-10)
 --------------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,8 +11,8 @@ dependencies:
   - cftime
   - cf_xarray >=0.7.6
   - clisops >=0.15
-  - dask >=2024.8.1,<2024.12  # FIXME: Remove upper pin when https://github.com/pangeo-data/rechunker/pull/156 is merged
-  - flox !=0.9.14  # FIXME: 0.9.14 is a broken version. This pin could be removed eventually.
+  - dask >=2024.8.1
+  - flox
   - fsspec
   - geopandas
   - h5netcdf
@@ -26,12 +26,12 @@ dependencies:
   - pandas >=2.2
   - parse
   - pyyaml
-  - rechunker
+  - rechunker >=0.5.3
   - scipy >=1.10
   - shapely >=2.0
   - sparse
   - toolz
-  - xarray >=2023.11.0, !=2024.6.0
+  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0,  # FIXME: Remove the highest version when rechunker is updated.
   - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,7 +27,7 @@ dependencies:
   - parse
   - pyyaml
   - rechunker >=0.5.3
-  - scipy >=1.10
+  - scipy >=1.11.0
   - shapely >=2.0
   - sparse
   - toolz

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,7 @@ dependencies:
   - shapely >=2.0
   - sparse
   - toolz
-  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0,  # FIXME: Remove the highest version when rechunker is updated.
+  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0  # FIXME: Remove the highest version when rechunker is updated.
   - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -32,7 +32,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.55.1, <0.56
+  - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3
   - xsdba >=0.3.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask >=2024.8.1
   - flox
   - fsspec
-  - geopandas
+  - geopandas >=1.0
   - h5netcdf
   - h5py
   - intake-esm >=2023.07.07

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,8 @@ dependencies:
   - cftime
   - cf_xarray >=0.7.6
   - clisops >=0.15
-  - dask >=2024.8.1,<2024.12  # FIXME: Remove upper pin when https://github.com/pangeo-data/rechunker/pull/156 is merged
-  - flox !=0.9.14  # FIXME: 0.9.14 is a broken version. This pin could be removed eventually.
+  - dask >=2024.8.1
+  - flox
   - fsspec
   - geopandas
   - h5netcdf
@@ -26,12 +26,12 @@ dependencies:
   - pandas >=2.2
   - parse
   - pyyaml
-  - rechunker
+  - rechunker >=0.5.3
   - scipy >=1.10
   - shapely >=2.0
   - sparse
   - toolz
-  - xarray >=2023.11.0, !=2024.6.0
+  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0,  # FIXME: Remove the highest version when rechunker is updated.
   - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - shapely >=2.0
   - sparse
   - toolz
-  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0,  # FIXME: Remove the highest version when rechunker is updated.
+  - xarray >=2023.11.0, !=2024.6.0, <=2025.3.0  # FIXME: Remove the highest version when rechunker is updated.
   - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.55.1, <0.56
+  - xclim >=0.56, <0.57
   - xesmf >=0.7, !=0.8.8
   - zarr >=2.13, <3
   - xsdba >=0.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask >=2024.8.1
   - flox
   - fsspec
-  - geopandas
+  - geopandas >=1.0
   - h5netcdf
   - h5py
   - intake-esm >=2023.07.07
@@ -27,7 +27,7 @@ dependencies:
   - parse
   - pyyaml
   - rechunker >=0.5.3
-  - scipy >=1.10
+  - scipy >=1.11.0
   - shapely >=2.0
   - sparse
   - toolz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   "sparse",
   "toolz",
   "xarray >=2023.11.0, !=2024.6.0",
-  "xclim >=0.55.1, <0.56",
+  "xclim >=0.56, <0.57",
   "xsdba>=0.3.0",
   "zarr >=2.13,<3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "dask >=2024.8.1",
   "flox",
   "fsspec",
-  "geopandas",
+  "geopandas >=1.0",
   "h5netcdf",
   "h5py", # <3.11", # writing and reading with engine h5netcdf was broken
   "intake-esm >=2023.07.07",
@@ -57,7 +57,7 @@ dependencies = [
   "pyarrow >=10.0.1",
   "pyyaml",
   "rechunker >=0.5.3",
-  "scipy >=1.10",
+  "scipy >=1.11.0",
   "shapely >=2.0",
   "sparse",
   "toolz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "cftime",
   "cf_xarray >=0.7.6",
   "clisops >=0.15",
-  "dask >=2024.8.1,",
+  "dask >=2024.8.1",
   "flox",
   "fsspec",
   "geopandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ dependencies = [
   "cftime",
   "cf_xarray >=0.7.6",
   "clisops >=0.15",
-  "dask >=2024.8.1,<2024.12.0", # FIXME: Remove upper pin when https://github.com/pangeo-data/rechunker/pull/156 is merged
-  "flox !=0.9.14", # FIXME: 0.9.14 is a broken version. This pin could be removed eventually.
+  "dask >=2024.8.1,",
+  "flox",
   "fsspec",
   "geopandas",
   "h5netcdf",
@@ -56,12 +56,12 @@ dependencies = [
   # Used when opening catalogs.
   "pyarrow >=10.0.1",
   "pyyaml",
-  "rechunker",
+  "rechunker >=0.5.3",
   "scipy >=1.10",
   "shapely >=2.0",
   "sparse",
   "toolz",
-  "xarray >=2023.11.0, !=2024.6.0",
+  "xarray >=2023.11.0, !=2024.6.0, <=2025.3.0", # FIXME: Remove the highest version when rechunker is updated.
   "xclim >=0.56, <0.57",
   "xsdba>=0.3.0",
   "zarr >=2.13,<3"

--- a/src/xscen/diagnostics.py
+++ b/src/xscen/diagnostics.py
@@ -12,13 +12,11 @@ import numpy as np
 import xarray as xr
 import xclim as xc
 import xclim.core.dataflags
+from xclim.core import ValidationError
+from xclim.core.formatting import (  # noqa: F401
+    _merge_attrs_drop_conflicts as merge_attrs,
+)
 from xclim.core.indicator import Indicator
-
-# FIXME: Remove this when updating minimum xclim version to 0.53
-try:  # Changed in xclim 0.53
-    from xclim.core import ValidationError
-except ImportError:
-    from xclim.core.utils import ValidationError
 
 from .config import parse_config
 from .indicators import load_xclim_module
@@ -522,9 +520,7 @@ def measures_heatmap(
     )
     ds_hmap = ds_hmap.to_dataset(name="heatmap")
 
-    ds_hmap.attrs = xr.core.merge.merge_attrs(
-        [ds.attrs for ds in meas_datasets], combine_attrs="drop_conflicts"
-    )
+    ds_hmap.attrs = merge_attrs(*[ds for ds in meas_datasets])
     ds_hmap = clean_up(
         ds=ds_hmap,
         common_attrs_only=meas_datasets,


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Updates `xclim` and almost the latest `xarray`. `rechunker` is compatible with `xarray v2025.3.0`, but not `v2025.3.1`.
* Updates `rechunker` and removes the pin on `dask`. 
* Removes the pin on `flox`, it's been more than long enough.

### Does this PR introduce a breaking change?


### Other information:
