### PR TITLE
add strict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`).
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add annual global tas timeseries for CMIP6's model UKESM1-0-LL ssp585 r4i1p1f2 (:pull:`573`).
-* Add `strict_units` option to health checks. (:pull:`574`, :issue: `574`).
+* Add `strict_units` option to health checks. (:pull:`574`, :issue:`574`).
 
 v0.12.1 (2025-04-07)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`).
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add annual global tas timeseries for CMIP6's model UKESM1-0-LL ssp585 r4i1p1f2 (:pull:`573`).
-* Add `units_strict` option to health checks. (:pull:`574`, :issue: `574`).
+* Add `strict_units` option to health checks. (:pull:`574`, :issue: `574`).
 
 v0.12.1 (2025-04-07)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`).
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add annual global tas timeseries for CMIP6's model UKESM1-0-LL ssp585 r4i1p1f2 (:pull:`573`).
+* Add `units_strict` option to health checks. (:pull:`574`, :issue: `574`).
 
 v0.12.1 (2025-04-07)
 --------------------

--- a/src/xscen/diagnostics.py
+++ b/src/xscen/diagnostics.py
@@ -221,7 +221,7 @@ def health_checks(  # noqa: C901
                         _error(f"'{v}' ValidationError: {e}", "variables_and_units")
                 # are they technically the same
                 close_enough = xc.units.str2pint(
-                    ds[v].attrs.get("units", None)
+                    ds[v].attrs["units"]
                 ) == xc.units.str2pint(variables_and_units[v])
 
                 if strict_units or not close_enough:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #574
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Add option `strict_units` to `health_checks`. 

### Does this PR introduce a breaking change?
yes, now the default thinks degC and °C are the same thing.
To go back to previous behavior, make `strict_units` True.

### Other information:
