### PR TITLE
Always check units

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,7 +119,7 @@ repos:
       - id: check-github-workflows
       - id: check-readthedocs
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.5.2
+    rev: v1.5.1  # FIXME: Rust is missing on our systems to support 1.5.2+
     hooks:
       - id: zizmor
         args: [ '--config=.zizmor.yml' ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,17 @@ Changelog
 
 v0.13 (unreleased)
 --------------------
-Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`).
+Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add annual global tas timeseries for CMIP6's model UKESM1-0-LL ssp585 r4i1p1f2 (:pull:`573`).
 * Add `strict_units` option to health checks. (:pull:`574`, :issue:`574`).
-* Add 10yr and 30yr frequencies support in CVs (:pull:`576`)
+* Add 10yr and 30yr frequencies support in CVs. (:pull:`576`).
+
+Bug fixes
+^^^^^^^^^
+* ``xs.utils.change_units`` will now always check that the units returned are exactly the same as the requested units. (:pull:`578`).
 
 v0.12.1 (2025-04-07)
 --------------------

--- a/src/xscen/utils.py
+++ b/src/xscen/utils.py
@@ -844,14 +844,13 @@ def change_units(ds: xr.Dataset, variables_and_units: dict) -> xr.Dataset:
                         raise ValueError(
                             f"No known transformation between {ds[v].units} and {variables_and_units[v]} (temporal dimensionality mismatch)."
                         )
-                    # update unit name if physical units are equal but not their name (ex. degC vs °C)
-                    if (
-                        units.units2pint(ds[v])
-                        != units.units2pint(variables_and_units[v])
-                    ) and (ds[v].units != variables_and_units[v]):
-                        ds = ds.assign(
-                            {v: ds[v].assign_attrs(units=variables_and_units[v])}
-                        )
+                # update unit name if physical units are equal but not their name (ex. degC vs °C)
+                if (
+                    units.units2pint(ds[v]) != units.units2pint(variables_and_units[v])
+                ) and (ds[v].units != variables_and_units[v]):
+                    ds = ds.assign(
+                        {v: ds[v].assign_attrs(units=variables_and_units[v])}
+                    )
 
     return ds
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -404,7 +404,7 @@ class TestPropertiesMeasures:
         p, m = xs.properties_and_measures(
             self.ds,
             properties=self.yaml_file,
-            change_units_arg={"tas": "degC"},
+            change_units_arg={"tas": "°C"},
         )
 
         assert p["mean-tas"].attrs["units"] == "°C"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -477,6 +477,9 @@ class TestVariablesUnits:
         assert out.tas.attrs["units"] == "degK"
         np.testing.assert_array_equal(out.tas, ds.tas)
 
+        out2 = xs.clean_up(ds, variables_and_units={"tas": "°K"})
+        assert out2.tas.attrs["units"] == "°K"
+
     def test_variables_2(self):
         ds = timeseries(
             np.tile(np.arange(1, 13), 3),
@@ -504,7 +507,7 @@ class TestVariablesUnits:
             as_dataset=True,
         )
         out = xs.clean_up(ds, variables_and_units={"pr": "mm/day"})
-        assert out.pr.attrs["units"] == "mm d-1"
+        assert out.pr.attrs["units"] == "mm/day"
         np.testing.assert_array_almost_equal(out.pr, ds.pr * 86400)
 
     def test_variables_amount2rate(self):
@@ -516,7 +519,7 @@ class TestVariablesUnits:
             units="mm",
             as_dataset=True,
         )
-        out = xs.clean_up(ds, variables_and_units={"pr": "mm/day"})
+        out = xs.clean_up(ds, variables_and_units={"pr": "mm d-1"})
         assert out.pr.attrs["units"] == "mm d-1"
         np.testing.assert_array_almost_equal(out.pr, ds.pr)
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `change_units` will now always check if the units returned by `xclim` are exactly the units requested.

### Does this PR introduce a breaking change?


### Other information:
