### PR TITLE
Remove adaptfreq from xscen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,10 +123,10 @@ repos:
     hooks:
       - id: zizmor
         args: [ '--config=.zizmor.yml' ]
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.25.1
-    hooks:
-      - id: gitleaks
+#  - repo: https://github.com/gitleaks/gitleaks
+#    rev: v8.25.1
+#    hooks:
+#      - id: gitleaks
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,10 +123,10 @@ repos:
     hooks:
       - id: zizmor
         args: [ '--config=.zizmor.yml' ]
-#  - repo: https://github.com/gitleaks/gitleaks
-#    rev: v8.25.1
-#    hooks:
-#      - id: gitleaks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.25.1
+    hooks:
+      - id: gitleaks
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ v0.13 (unreleased)
 --------------------
 Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Remove `adapt_freq` argument from `xs.train`. This argument should be passed to xsdba directly. (:pull:`586`).
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add annual global tas timeseries for CMIP6's model UKESM1-0-LL ssp585 r4i1p1f2 (:pull:`573`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Éric Du
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* Remove `adapt_freq` argument from `xs.train`. This argument should be passed to xsdba directly. (:pull:`586`).
+* Remove `adapt_freq` argument from `xs.train`. This argument should be passed to xsdba directly. (:pull:`589`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/notebooks/2_getting_started.ipynb
+++ b/docs/notebooks/2_getting_started.ipynb
@@ -811,7 +811,6 @@
     "- `period` defines the period used for building the transfer function.\n",
     "- `method` indicates which bias adjusting method to call within `xsdba`.\n",
     "- `maximal_calendar` instructs on which calendar to use, following this hierarchy: 360_day < noleap < standard < all_leap\n",
-    "- `adapt_freq` is used for bias adjusting the frequency of dry/wet days (precipitation only).\n",
     "- `jitter_under` adds a random noise under a given threshold.\n",
     "- `jitter_over`adds a random noise over a given threshold.\n",
     "- `xsdba_train_kwargs` is described above.\n",

--- a/src/xscen/biasadjust.py
+++ b/src/xscen/biasadjust.py
@@ -26,7 +26,12 @@ def _add_preprocessing_attr(scen, train_kwargs):
     fake_ref = xr.DataArray(name="ref")
     fake_hist = xr.DataArray(name="hist")
 
+    scen.attrs[
+        "bias_adjustment"
+    ] += f" with xsdba_train_args: {train_kwargs['xsdba_train_args']}"
+
     preproc = []
+
     if train_kwargs["jitter_under"] is not None:
         preproc.append(
             xc.core.formatting.gen_call_string(
@@ -65,7 +70,6 @@ def train(
     xsdba_train_args: dict | None = None,
     xclim_train_args: dict | None = None,
     maximal_calendar: str = "noleap",
-    adapt_freq: dict | None = None,
     jitter_under: dict | None = None,
     jitter_over: dict | None = None,
     align_on: str | None = "year",
@@ -96,8 +100,6 @@ def train(
     maximal_calendar: str
       Maximal calendar dhist can be. The hierarchy: 360_day < noleap < standard < all_leap.
       If dhist's calendar is higher than maximal calendar, it will be converted to the maximal calendar.
-    adapt_freq: dict, optional
-      If given, a dictionary of args to pass to the frequency adaptation function.
     jitter_under: dict, optional
       If given, a dictionary of args to pass to `jitter_under_thresh`.
     jitter_over: dict, optional
@@ -182,23 +184,16 @@ def train(
             ref = xsdba.processing.jitter_under_thresh(ref, **jitter_under)
             hist = xsdba.processing.jitter_under_thresh(hist, **jitter_under)
 
-        if adapt_freq is not None:
-            adapt_freq.setdefault("group", group)
-            hist, pth, dP0 = xsdba.processing.adapt_freq(ref, hist, **adapt_freq)
-            adapt_freq.pop("group")
-
         ADJ = getattr(xsdba.adjustment, method).train(ref, hist, **xsdba_train_args)
 
-    if adapt_freq is not None:
-        ds = ADJ.ds.assign(pth=pth, dP0=dP0)
-    else:
-        ds = ADJ.ds
+    ds = ADJ.ds
 
     # Arguments that need to be transferred to the adjust() function
+    xsdba_train_args.pop("group", None)
     ds.attrs["train_params"] = {
         "var": var,
         "maximal_calendar": maximal_calendar,
-        "adapt_freq": adapt_freq,
+        "xsdba_train_args": xsdba_train_args,
         "jitter_under": jitter_under,
         "jitter_over": jitter_over,
         "period": period,

--- a/src/xscen/biasadjust.py
+++ b/src/xscen/biasadjust.py
@@ -44,12 +44,6 @@ def _add_preprocessing_attr(scen, train_kwargs):
                 "jitter_over_thresh", fake_ref, fake_hist, train_kwargs["jitter_over"]
             )
         )
-    if train_kwargs["adapt_freq"] is not None:
-        preproc.append(
-            xc.core.formatting.gen_call_string(
-                "adapt_freq", fake_ref, fake_hist, train_kwargs["adapt_freq"]
-            )
-        )
 
     if preproc:
         scen.attrs[

--- a/templates/1-basic_workflow_with_config/config1.yml
+++ b/templates/1-basic_workflow_with_config/config1.yml
@@ -220,7 +220,6 @@ biasadjust:
         kind: "*"
         nquantiles: 50
       #maximal_calendar:
-      #adapt_freq:
       #jitter_under:
       #jitter_over:
       #align_on:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* As discussed previously, `adapt_freq` should be passed directly to xsdba, not before through xscen. Hence, I am removing it as an option in xscen.

### Does this PR introduce a breaking change?
yes, you can't call use the arg `adapt_freq` anymore. Instead, pass it through xsdba with `xsdba_train_args=dict(adapt_freq_thresh="2 K")`.

### Other information:
