### PR TITLE
Iterative creeping - save and load weights

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+v0.13 (unreleased)
+------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Add possibility to "creep fill" iteratively with argument ``steps`` in ``xs.spatial.creep_weights``. (:pull:`594`).
+* Ability to save and load sparse arrays like the creep or regridding weights to disk with ``xs.io.save_sparse``  and ``xs.io.load_sparse``. (:pull:`594`).
+
 v0.12.2 (2025-05-16)
 --------------------
 Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`), Gabriel Rondeau-Genesse (:user:`RondeauG`).

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -143,6 +143,12 @@ class TestCreepFill:
         np.testing.assert_equal(out.isel(lat=0, lon=0), np.tile(np.nan, 3))
         np.testing.assert_equal(out.isel(lat=3, lon=3), np.tile(np.nan, 3))
 
+    def test_steps(self):
+        # TODO: More in-depth testing ?
+        w = xs.spatial.creep_weights(self.ds["mask"], n=1, steps=2, mode="clip")
+        out = xs.spatial.creep_fill(self.ds["tas"], w)
+        assert "step" in w.dims
+
 
 class TestGetGrid:
     def test_none(self):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* New argument `steps` to `creep_weights` so that we creep iteratively this number of time, so filling a boundary of thickness `steps * n`. The `creep_fill` detects it and applies the weights in sequence too.
* New methods to save those weights to disk and then load them back. Similar to what `xESMF` does, but for our own `creep_fill`. This syntax is completely xscen-specific. In theory CF conventions have what it needs to encode/decode sparse arrays, but the implementation is still to be done.

### Does this PR introduce a breaking change?
No.


### Other information:
I already use that technique in PC for the sea masking. And I now want to use that for SPS. The idea is that `creep_weights` is slow but `creep_fill` is fast, so if the mask is constant, you don't want to recompute it often.


Peut-être que ceci pourrait être utile à @DoMatte.