### PR TITLE
Obs utils

### DIFF
--- a/src/xscen/regrid.py
+++ b/src/xscen/regrid.py
@@ -410,7 +410,33 @@ def create_bounds_gridmapping(ds: xr.Dataset, gridmap: str | None = None) -> xr.
         f"{xname}_vertices", f"{yname}_vertices"
     )
 
-    RP = ccrs.Projection(CRS.from_cf(ds[gridmap].attrs))
+    # Some CRS have additional attributes according to CF conventions
+    def _get_opt_attr_as_float(da: xr.DataArray, attr: str) -> float | None:
+        return float(da.attrs[attr]) if attr in da.attrs else None
+
+    if gridmap == "rotated_pole":
+        # Get cartopy's crs for the projection
+        RP = ccrs.RotatedPole(
+            pole_longitude=float(ds.rotated_pole.grid_north_pole_longitude),
+            pole_latitude=float(ds.rotated_pole.grid_north_pole_latitude),
+            central_rotated_longitude=_get_opt_attr_as_float(
+                ds.rotated_pole, "north_pole_grid_longitude"
+            ),
+        )
+    elif gridmap == "oblique_mercator":
+        RP = ccrs.ObliqueMercator(
+            central_longitude=float(ds.oblique_mercator.longitude_of_projection_origin),
+            central_latitude=float(ds.oblique_mercator.latitude_of_projection_origin),
+            false_easting=_get_opt_attr_as_float(ds.oblique_mercator, "false_easting"),
+            false_northing=_get_opt_attr_as_float(
+                ds.oblique_mercator, "false_northing"
+            ),
+            scale_factor=float(ds.oblique_mercator.scale_factor_at_projection_origin),
+            azimuth=float(ds.oblique_mercator.azimuth_of_central_line),
+        )
+    else:
+        raise NotImplementedError(f"Grid mapping {gridmap} not yet implemented.")
+
     PC = ccrs.PlateCarree()
 
     # Project points

--- a/src/xscen/regrid.py
+++ b/src/xscen/regrid.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import cartopy.crs as ccrs
 import cf_xarray as cfxr
 import xarray as xr
+from pyproj import CRS
 from xclim.core.units import convert_units_to
 
 try:
@@ -397,11 +398,11 @@ def create_bounds_gridmapping(ds: xr.Dataset, gridmap: str | None = None) -> xr.
     xname = ds.cf.axes["X"][0]
     yname = ds.cf.axes["Y"][0]
 
-    ds = ds.cf.add_bounds([yname, xname])
+    dsb = ds.cf.add_bounds([yname, xname])
 
     # In "vertices" format then expand to 2D. From (N, 2) to (N+1,) to (N+1, M+1)
-    yv1D = cfxr.bounds_to_vertices(ds[f"{yname}_bounds"], "bounds")
-    xv1D = cfxr.bounds_to_vertices(ds[f"{xname}_bounds"], "bounds")
+    yv1D = cfxr.bounds_to_vertices(dsb[f"{yname}_bounds"], "bounds")
+    xv1D = cfxr.bounds_to_vertices(dsb[f"{xname}_bounds"], "bounds")
     yv = yv1D.expand_dims(dict([(f"{xname}_vertices", xv1D)])).transpose(
         f"{xname}_vertices", f"{yname}_vertices"
     )
@@ -409,33 +410,7 @@ def create_bounds_gridmapping(ds: xr.Dataset, gridmap: str | None = None) -> xr.
         f"{xname}_vertices", f"{yname}_vertices"
     )
 
-    # Some CRS have additional attributes according to CF conventions
-    def _get_opt_attr_as_float(da: xr.DataArray, attr: str) -> float | None:
-        return float(da.attrs[attr]) if attr in da.attrs else None
-
-    if gridmap == "rotated_pole":
-        # Get cartopy's crs for the projection
-        RP = ccrs.RotatedPole(
-            pole_longitude=float(ds.rotated_pole.grid_north_pole_longitude),
-            pole_latitude=float(ds.rotated_pole.grid_north_pole_latitude),
-            central_rotated_longitude=_get_opt_attr_as_float(
-                ds.rotated_pole, "north_pole_grid_longitude"
-            ),
-        )
-    elif gridmap == "oblique_mercator":
-        RP = ccrs.ObliqueMercator(
-            central_longitude=float(ds.oblique_mercator.longitude_of_projection_origin),
-            central_latitude=float(ds.oblique_mercator.latitude_of_projection_origin),
-            false_easting=_get_opt_attr_as_float(ds.oblique_mercator, "false_easting"),
-            false_northing=_get_opt_attr_as_float(
-                ds.oblique_mercator, "false_northing"
-            ),
-            scale_factor=float(ds.oblique_mercator.scale_factor_at_projection_origin),
-            azimuth=float(ds.oblique_mercator.azimuth_of_central_line),
-        )
-    else:
-        raise NotImplementedError(f"Grid mapping {gridmap} not yet implemented.")
-
+    RP = ccrs.Projection(CRS.from_cf(ds[gridmap].attrs))
     PC = ccrs.PlateCarree()
 
     # Project points

--- a/src/xscen/spatial.py
+++ b/src/xscen/spatial.py
@@ -476,3 +476,16 @@ def update_history_and_name(ds_subset, new_history, name):
     if name is not None:
         ds_subset.attrs["cat:domain"] = name
     return ds_subset
+
+
+def dataset_extent(ds, method: str = 'shape', name=None) -> dict:
+    """The dataset's spatial extent expressed a xscen Region spec.
+
+    Parameters
+    ----------
+    ds: Dataset
+        A dataset containing a grid with latitude and longitude coordinates.
+    method : {'shape', 'bbox'}
+        One of the two methods recognized by xscen to specify an area.
+        "shape" will compute a shapely polygon in latitude longitude coordinates from
+        the cell bounds which requires a grid mapping understood by :`py:

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -197,6 +197,7 @@ class TestGetGrid:
             as_dataset=True,
         )
         ds["tas"].attrs["grid_mapping"] = "lambert_conformal_conic"
+
         with pytest.warns(
             UserWarning, match="There are conflicting grid_mapping attributes"
         ):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Adds the  following functions to `xs.spatial`

- `dataset_extent` which returns a "region" dict with the extent of a given dataset.
- `merge_duplicated_stations`  : merges stations with the same location from a station-obs dataset
- `voronoi_weights` : For a stations dataset, return a weight that is inversely proportional to the station density around each station. The idea is to remove station density bias when taking means of parameters computed over stations.

Also, these changes:
- Fix for scipy 1.16. This fix is different than what @juliettelavoie did in #616. Here, I preserve the behaviour. Which do we prefer ?
- Fixes in `subset`:
    + `method='gridpoint'` : when the lon/lat is a DataArray, its dimension name is preserved (instead of being replaced by `site`)
    + `method='shape'` : a shapely polygon is also accepted
- `get_grid_mapping` : allow a grid mapping to be in the data vars as well
- Doc of regions : I tried to add a `Region` typevar in the aim of having better annotations for this construct, instead of "dict2.

### Does this PR introduce a breaking change?
No.

### Other information:
I had ambitions of relying more on cf-xarray for grid mapping handling but it turns out it didn't work. Oh well.