### PR TITLE
Fixed spatial_mean always using spatialAverager's default dimension name

### DIFF
--- a/src/xscen/aggregate.py
+++ b/src/xscen/aggregate.py
@@ -857,15 +857,18 @@ def spatial_mean(  # noqa: C901
 
         savg = xe.SpatialAverager(ds, geoms, **kwargs_copy)
         ds_agg = savg(ds, keep_attrs=True, **call_kwargs)
+
+        geom_dim_name = kwargs_copy.pop("geom_dim_name", "geom")
+
         extra_coords = {
-            col: xr.DataArray(polygon[col], dims=("geom",))
+            col: xr.DataArray(polygon[col], dims=(geom_dim_name,))
             for col in polygon.columns
             if col != "geometry"
         }
-        extra_coords["geom"] = xr.DataArray(polygon.index, dims=("geom",))
+        extra_coords[geom_dim_name] = xr.DataArray(polygon.index, dims=(geom_dim_name,))
         ds_agg = ds_agg.assign_coords(**extra_coords)
         if len(polygon) == 1:
-            ds_agg = ds_agg.squeeze("geom")
+            ds_agg = ds_agg.squeeze(geom_dim_name)
         if "lon_bounds" in ds_agg:
             ds_agg = ds_agg.assign_coords(
                 {"lon_bounds": ds_agg.lon_bounds, "lat_bounds": ds_agg.lat_bounds}


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x ] This PR does not seem to break the templates.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Fix: [xscen.spatial_mean](https://github.com/Ouranosinc/xscen/blob/main/src/xscen/aggregate.py#L636) now reuses the custom dimension name "geom_dim_name" provided via "kwargs" to [xesmf.spatialAverager](https://github.com/pangeo-data/xESMF/blob/master/xesmf/frontend.py#L1123), defaulting back to "geom" when not specified.

This is needed because the current implementation of xscen.spatial_mean always outputs a dataset with dimension "geom". As such, if someone passes:
`kwargs = {"geom_dim_name": "region"}`
The output dataset will have both "geom" and "region" dimensions.

### Does this PR introduce a breaking change?
No

### Other information:
