### PR TITLE
Pin intake-esm to avoid bugs following implementation of polars for reading csvs + Fix for new scipy linregress + Fix for xsdba attributes

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,7 +17,7 @@ dependencies:
   - geopandas >=1.0
   - h5netcdf
   - h5py
-  - intake-esm >=2025.2.3
+  - intake-esm ==2025.2.3
   - matplotlib >=3.6
   - netcdf4
   - numcodecs <0.16.0

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - geopandas >=1.0
   - h5netcdf
   - h5py
-  - intake-esm >=2025.2.3
+  - intake-esm ==2025.2.3
   - matplotlib >=3.6
   - netcdf4
   - numcodecs <0.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "geopandas >=1.0",
   "h5netcdf",
   "h5py",
-  "intake-esm >=2025.2.3",
+  "intake-esm ==2025.2.3",
   "matplotlib >=3.6",
   "netcdf4",
   "numcodecs <0.16.0",

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -172,7 +172,7 @@ class TestAdjust:
             out["tas"].attrs["bias_adjustment"]
             == "DetrendedQuantileMapping(group=Grouper("
             "name='time.dayofyear', window=31), kind='+'"
-            ", adapt_freq_thresh='2 K').adjust(sim, ) with xsdba_train_args: {}"
+            ", adapt_freq_thresh=None).adjust(sim, ) with xsdba_train_args: {}"
         )
         assert out.time.dt.calendar == "noleap"
 
@@ -350,7 +350,8 @@ class TestAdjust:
                 "kind": "*",
                 "nquantiles": 50,
                 # FIXME: when xsdba can handle mm/d correctly
-                "adapt_freq_thresh": "1.157e-05 kg/m2/s",
+                # FIXME: Can't use adapt_freq_thresh because randomness is involved
+                # "adapt_freq_thresh": "1.157e-05 kg/m2/s",
             },
         )
 
@@ -377,14 +378,13 @@ class TestAdjust:
 
             # xsdba is now climate-agnostic, patch xclim's converter
             with xclim_convert_units_to():
-
                 QM = xsdba.DetrendedQuantileMapping.train(
                     drefx["pr"],
                     dhistx["pr"],
                     group=group,
                     kind="*",
                     nquantiles=50,
-                    adapt_freq_thresh="1.157e-05 kg/m2/s",
+                    # adapt_freq_thresh="1.157e-05 kg/m2/s",
                 )
 
                 detrend = xsdba.detrending.LoessDetrend(
@@ -397,7 +397,7 @@ class TestAdjust:
                     extrapolation="constant",
                 ).rename({"scen": "pr"})
 
-        assert out_xscen.equals(out_xclim)
+        xr.testing.assert_equal(out_xscen, out_xclim)
 
     def test_additive_space(self):
         data = np.random.random(365 * 3) * 90

--- a/tests/test_biasadjust.py
+++ b/tests/test_biasadjust.py
@@ -172,7 +172,7 @@ class TestAdjust:
             out["tas"].attrs["bias_adjustment"]
             == "DetrendedQuantileMapping(group=Grouper("
             "name='time.dayofyear', window=31), kind='+'"
-            ").adjust(sim, ) with xsdba_train_args: {}"
+            ", adapt_freq_thresh='2 K').adjust(sim, ) with xsdba_train_args: {}"
         )
         assert out.time.dt.calendar == "noleap"
 
@@ -241,7 +241,7 @@ class TestAdjust:
         assert (
             out.tas.attrs["bias_adjustment"]
             == "DetrendedQuantileMapping(group=Grouper(name='time.dayofyear',"
-            " window=31), kind='+').adjust(sim, detrend=<LoessDetrend>)"
+            " window=31), kind='+', adapt_freq_thresh='2 K').adjust(sim, detrend=<LoessDetrend>)"
             " with xsdba_train_args: {'adapt_freq_thresh': '2 K'},"
             " ref and hist were prepared with jitter_under_thresh(ref, hist,"
             " {'thresh': '2 K'}) and jitter_over_thresh(ref, hist, {'upper_bnd':"
@@ -251,7 +251,7 @@ class TestAdjust:
         assert (
             out2.tas.attrs["bias_adjustment"]
             == "DetrendedQuantileMapping(group=Grouper(name='time.dayofyear',"
-            " window=31), kind='+').adjust(sim, detrend=<LoessDetrend>)"
+            " window=31), kind='+', adapt_freq_thresh='2 K').adjust(sim, detrend=<LoessDetrend>)"
             " with xsdba_train_args: {'adapt_freq_thresh': '2 K'}, "
             "ref and hist were prepared with jitter_under_thresh(ref, hist, {'thresh':"
             " '2 K'}) and jitter_over_thresh(ref, hist, {'upper_bnd': '3 K',"


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Pin temporaire, en attendant un fix pour #618. Probablement que ça prend un changement upstream, dans `intake-esm`, lui-même, donc faudra être patient.
* Répare les tests pour un changement dans les arguments de xsdba
* Importe les fix de tests pour linregress de scipy 1.16

### Does this PR introduce a breaking change?
No.

### Other information:
