### PR TITLE
Realization not required to be a dim on `subset_warming_level`

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -578,14 +578,27 @@ class TestSubsetWarmingLevel:
                     ds.tas.isnull().all(dim="time"), [False, True, True, True]
                 )
 
-    def test_multireals(self):
-        ds = self.ds.expand_dims(
-            realization=[
-                "CMIP6_CanESM5_ssp126_r1i1p1f1",
-                "CMIP6_CanESM5_ssp245_r1i1p1f1",
-                "fake_faux_falsch_falso",
-            ]
-        )
+    @pytest.mark.parametrize("asaux", [True, False])
+    def test_multireals(self, asaux):
+        if asaux:
+            ds = self.ds.expand_dims(real=[0, 1, 2]).assign_coords(
+                realization=(
+                    ("real",),
+                    [
+                        "CMIP6_CanESM5_ssp126_r1i1p1f1",
+                        "CMIP6_CanESM5_ssp245_r1i1p1f1",
+                        "fake_faux_falsch_falso",
+                    ],
+                )
+            )
+        else:
+            ds = self.ds.expand_dims(
+                realization=[
+                    "CMIP6_CanESM5_ssp126_r1i1p1f1",
+                    "CMIP6_CanESM5_ssp245_r1i1p1f1",
+                    "fake_faux_falsch_falso",
+                ]
+            )
         ds_sub = xs.subset_warming_level(
             ds,
             wl=1.5,
@@ -596,6 +609,8 @@ class TestSubsetWarmingLevel:
             ds_sub.warminglevel_bounds[:2].dt.year, [[[2004, 2023]], [[2004, 2023]]]
         )
         assert ds_sub.warminglevel_bounds[2].isnull().all()
+
+        ds
 
     def test_multilevels(self):
         ds_sub = xs.subset_warming_level(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] This PR does not seem to break the templates.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
In `subset_warming_level`, if we want to vectorize on realizations, it was previously needed that `ds.realization` be a dimension of the dataset. This is common, but makes it impossible to have multiple identical "realizations" in the dataset. This case happens when dealing with RCMs (multiple runs from the same GCM).

This PR solves the issue with a minimal change : `ds.realization` can be an auxiliary coord.

### Does this PR introduce a breaking change?
No.
