### PR TITLE
Update to xclim 0.58

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.13 (unreleased)
 --------------------
-Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`),  Pascal Bourgault (:user:`aulemahal`), Artem Buyalo (:user:`ArtemBuyalo`).
+Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`), Artem Buyalo (:user:`ArtemBuyalo`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,6 +14,7 @@ New features and enhancements
 * Ability to save and load sparse arrays like the creep or regridding weights to disk with ``xs.io.save_sparse``  and ``xs.io.load_sparse``. (:pull:`594`).
 * Generalize ``xs.regrid.create_bounds_gridmapping`` to include dataset with `crs`. (:pull:`628`, :issue:`627`).
 * Ability to return multiple periods if passed multiple warming levels in ``xs.extract.get_period_from_warming_level``. (:pull:`630`, :issue:`629`).
+* Update xscen to xclim 0.58 (:pull:`634`).
 
 Bug fixes
 ^^^^^^^^^

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,7 +34,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.58, <0.59
+  - xclim >=0.56, <0.59
   - xsdba >=0.4.0
   - zarr >=2.13, <3
   # Opt

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,7 +34,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.56, <0.58
+  - xclim >=0.58, <0.59
   - xsdba >=0.4.0
   - zarr >=2.13, <3
   # Opt

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.58, <0.59
+  - xclim >=0.56, <0.59
   - xsdba >=0.4.0
   - zarr >=2.13, <3
   # Opt

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - sparse
   - toolz
   - xarray >=2023.11.0, !=2024.6.0
-  - xclim >=0.56, <0.58
+  - xclim >=0.58, <0.59
   - xsdba >=0.4.0
   - zarr >=2.13, <3
   # Opt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   "sparse",
   "toolz",
   "xarray >=2023.11.0, !=2024.6.0",
-  "xclim >=0.56, <0.58",
+  "xclim >=0.58, <0.59",
   "xsdba >=0.4.0",
   "zarr >=2.13,<3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   "sparse",
   "toolz",
   "xarray >=2023.11.0, !=2024.6.0",
-  "xclim >=0.58, <0.59",
+  "xclim >=0.56, <0.59",
   "xsdba >=0.4.0",
   "zarr >=2.13,<3.0"
 ]
@@ -389,7 +389,7 @@ convention = "numpy"
 [tool.vulture]
 exclude = []
 ignore_decorators = ["@pytest.fixture"]
-ignore_names = []
+ignore_names = ["tas_midpoint"]
 min_confidence = 90
 paths = ["src/xscen", "tests"]
 sort_by_size = true

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -443,11 +443,11 @@ def resample(  # noqa: C901
         if all(v in ds for v in ["uas", "vas"]):
             uas, vas = ds.uas, ds.vas
         else:
-            uas, vas = xc.indicators.atmos.wind_vector_from_speed(
+            uas, vas = xc.indicators.convert.wind_vector_from_speed(
                 ds.sfcWind, ds.sfcWindfromdir
             )
         if "sfcWind" not in ds:
-            ds["sfcWind"], _ = xc.indicators.atmos.wind_speed_from_vector(
+            ds["sfcWind"], _ = xc.indicators.convert.wind_speed_from_vector(
                 uas=ds["uas"], vas=ds["vas"]
             )
 
@@ -473,7 +473,7 @@ def resample(  # noqa: C901
 
         # Prepare output
         if var_name in ["sfcWindfromdir"]:
-            _, out = xc.indicators.atmos.wind_speed_from_vector(uas=uas, vas=vas)
+            _, out = xc.indicators.convert.wind_speed_from_vector(uas=uas, vas=vas)
         else:
             out = ds[var_name]
 

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -18,6 +18,11 @@ from intake_esm.derived import DerivedVariableRegistry
 from scipy.interpolate import interp1d
 from xclim.core.calendar import compare_offsets
 
+try:
+    import xclim.indicators.convert as convert
+except ImportError:
+    import xclim.indicators.atmos as convert
+
 from .catalog import (
     ID_COLUMNS,
     DataCatalog,
@@ -443,11 +448,9 @@ def resample(  # noqa: C901
         if all(v in ds for v in ["uas", "vas"]):
             uas, vas = ds.uas, ds.vas
         else:
-            uas, vas = xc.indicators.convert.wind_vector_from_speed(
-                ds.sfcWind, ds.sfcWindfromdir
-            )
+            uas, vas = convert.wind_vector_from_speed(ds.sfcWind, ds.sfcWindfromdir)
         if "sfcWind" not in ds:
-            ds["sfcWind"], _ = xc.indicators.convert.wind_speed_from_vector(
+            ds["sfcWind"], _ = convert.wind_speed_from_vector(
                 uas=ds["uas"], vas=ds["vas"]
             )
 
@@ -473,7 +476,7 @@ def resample(  # noqa: C901
 
         # Prepare output
         if var_name in ["sfcWindfromdir"]:
-            _, out = xc.indicators.convert.wind_speed_from_vector(uas=uas, vas=vas)
+            _, out = convert.wind_speed_from_vector(uas=uas, vas=vas)
         else:
             out = ds[var_name]
 

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -20,7 +20,7 @@ from xclim.core.calendar import compare_offsets
 
 try:
     import xclim.indicators.convert as convert
-except ImportError:
+except ImportError:  # FIXME: Remove when we pin xclim >= 0.58
     import xclim.indicators.atmos as convert
 
 from .catalog import (

--- a/src/xscen/xclim_modules/conversions.py
+++ b/src/xscen/xclim_modules/conversions.py
@@ -6,6 +6,11 @@ import xarray as xr
 from xclim.core.units import convert_units_to, declare_units
 from xsdba.processing import from_additive_space, to_additive_space
 
+try:
+    from xclim.indicators.convert import mean_temperature_from_min_max as tas_midpoint
+except ImportError:
+    from xclim.indicators.atmos import tg as tas_midpoint
+
 
 @declare_units(prsn="[precipitation]", prlp="[precipitation]")
 def precipitation(prsn: xr.DataArray, prlp: xr.DataArray) -> xr.DataArray:

--- a/src/xscen/xclim_modules/conversions.py
+++ b/src/xscen/xclim_modules/conversions.py
@@ -7,11 +7,9 @@ from xclim.core.units import convert_units_to, declare_units
 from xsdba.processing import from_additive_space, to_additive_space
 
 try:
-    from xclim.indicators.convert import (
-        mean_temperature_from_max_and_min as tas_midpoint,
-    )
+    from xclim.indices.converters import tas_from_tasmin_tasmax as tas_midpoint
 except ImportError:  # FIXME: Remove when we pin xclim >= 0.58
-    from xclim.indicators.atmos import tg as tas_midpoint
+    from xclim.indices import tas as tas_midpoint
 
 
 @declare_units(prsn="[precipitation]", prlp="[precipitation]")

--- a/src/xscen/xclim_modules/conversions.py
+++ b/src/xscen/xclim_modules/conversions.py
@@ -7,8 +7,10 @@ from xclim.core.units import convert_units_to, declare_units
 from xsdba.processing import from_additive_space, to_additive_space
 
 try:
-    from xclim.indicators.convert import mean_temperature_from_min_max as tas_midpoint
-except ImportError:
+    from xclim.indicators.convert import (
+        mean_temperature_from_max_and_min as tas_midpoint,
+    )
+except ImportError:  # FIXME: Remove when we pin xclim >= 0.58
     from xclim.indicators.atmos import tg as tas_midpoint
 
 

--- a/src/xscen/xclim_modules/conversions.yml
+++ b/src/xscen/xclim_modules/conversions.yml
@@ -13,7 +13,7 @@ indicators:
   wind_vector_from_speed:
     base: wind_vector_from_speed
   tas_midpoint:
-    base: tas_midpoint
+    compute: tas_midpoint
     cf_attrs:
       - var_name: tas
   relative_humidity_from_dewpoint:

--- a/src/xscen/xclim_modules/conversions.yml
+++ b/src/xscen/xclim_modules/conversions.yml
@@ -13,7 +13,7 @@ indicators:
   wind_vector_from_speed:
     base: wind_vector_from_speed
   tas_midpoint:
-    base: mean_temperature_from_max_and_min
+    base: tas_midpoint
     cf_attrs:
       - var_name: tas
   relative_humidity_from_dewpoint:

--- a/src/xscen/xclim_modules/conversions.yml
+++ b/src/xscen/xclim_modules/conversions.yml
@@ -5,7 +5,7 @@ doc: |
 
   This module provides indicators generating base variables
   from other base variables. All indicators are non-resampling.
-realm: atmos
+realm: convert
 base: Indicator
 indicators:
   wind_speed_from_vector:
@@ -13,7 +13,7 @@ indicators:
   wind_vector_from_speed:
     base: wind_vector_from_speed
   tas_midpoint:
-    base: tg
+    base: mean_temperature_from_max_and_min
     cf_attrs:
       - var_name: tas
   relative_humidity_from_dewpoint:

--- a/src/xscen/xclim_modules/conversions.yml
+++ b/src/xscen/xclim_modules/conversions.yml
@@ -5,7 +5,8 @@ doc: |
 
   This module provides indicators generating base variables
   from other base variables. All indicators are non-resampling.
-realm: convert
+# FIXME: Change to "convert" when we pin xclim  >= 0.58
+realm: atmos
 base: Indicator
 indicators:
   wind_speed_from_vector:

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -276,7 +276,11 @@ def test_pattern_from_schema(samplecat):
 @pytest.mark.parametrize("hasver", [True, False])
 def test_build_path_ds(hasver):
     ds = xr.tutorial.open_dataset("air_temperature")
-    ds = ds.assign(time=xr.cftime_range("0001-01-01", freq="6h", periods=ds.time.size))
+    ds = ds.assign(
+        time=xr.date_range(
+            "0001-01-01", freq="6h", periods=ds.time.size, use_cftime=True
+        )
+    )
     ds.attrs.update(source="source", institution="institution")
     if hasver:
         ds.attrs["version"] = "v1"


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

- Refer to submodule `convert` for conversion indicators (in `resample`).
- Rename "tg" indicator to "mean_temperature_from_min_max" (in the conversion module)
- Move xclim pin to 0.58

I also avoided the usage of  `cftime_range` in a test to avoid a xarray warning.

### Does this PR introduce a breaking change?
~Yes, the valid xclim versions are shifted up.~

No, the changes are done within "try ... except ImportError" so both versions are still supported.

### Other information:
Tests will fail for now as xclim is not out on conda yet.