### PR TITLE
Fix Pandas 3 change when reading list of variables from files after parsing variables as strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Breaking changes
 Bug fixes
 ^^^^^^^^^
 * When creating cartopy CRS objects from CF attributes, xscen will default to a spherical earth of radius 6370997 m. This fixes issues raised by the update of PROJ 9.8 (:pull:`701`).
+* Fix a bug stemming from a change in Pandas 3 in ``parse_directory`` when ``read_from_file`` tries to overwrite a column previously parsed as strings. (:pull:`703`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/catutils.py
+++ b/src/xscen/catutils.py
@@ -447,6 +447,8 @@ def _parse_first_ds(grp: pd.DataFrame, cols: list[str], attrs_map: dict, xr_open
     logger.info(msg)
     out = grp.copy()
     for col, val in fromfile.items():
+        if isinstance(val, tuple) and out.dtypes[col] != "O":
+            out[col] = out[col].astype("O")
         for i in grp.index:  # If val is an iterable we can't use loc.
             out.at[i, col] = val
     return out

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -121,8 +121,8 @@ def test_parse_directory_readgroups(tmp_path):
     da = xr.DataArray(list("rien"), dims=("x",), coords={"x": range(4)})
     xr.Dataset({"abc": da, "ghi": da}).to_netcdf(tmp_path / "abc_sim1_exp.nc")
     xr.Dataset({"ijk": da, "mno": da}).to_netcdf(tmp_path / "ijk_sim1_exp.nc")
-    xr.Dataset({"abc": da, "ghi": da}).to_netcdf(tmp_path / "abc_sim2_exp.nc")
-    xr.Dataset({"ijk": da, "mno": da}).to_netcdf(tmp_path / "ijk_sim2_exp.nc")
+    xr.Dataset({"abc": da}).to_netcdf(tmp_path / "abc_sim2_exp.nc")
+    xr.Dataset({"ijk": da}).to_netcdf(tmp_path / "ijk_sim2_exp.nc")
 
     df = cu.parse_directory(
         directories=[str(tmp_path)],

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -117,21 +117,24 @@ def test_parse_directory():
     assert set(df[df["id"] == "CMIP6_ScenarioMIP_driver_NCC_NorESM2-MM_ssp126_1f1p1i1r_exreg"]["version"]) == {"v20191108", "v20200702"}
 
 
-@pytest.mark.requires_netcdf
-def test_parse_directory_readgroups():
+def test_parse_directory_readgroups(tmp_path):
+    da = xr.DataArray(list("rien"), dims=("x",), coords={"x": range(4)})
+    xr.Dataset({"abc": da, "ghi": da}).to_netcdf(tmp_path / "abc_sim1_exp.nc")
+    xr.Dataset({"ijk": da, "mno": da}).to_netcdf(tmp_path / "ijk_sim1_exp.nc")
+    xr.Dataset({"abc": da, "ghi": da}).to_netcdf(tmp_path / "abc_sim2_exp.nc")
+    xr.Dataset({"ijk": da, "mno": da}).to_netcdf(tmp_path / "ijk_sim2_exp.nc")
+
     df = cu.parse_directory(
-        directories=[str(SAMPLES_DIR)],
-        patterns=["{activity}/{domain}/{institution}/{source}/{experiment}/{member}/{frequency}/{?:_}.nc"],
+        directories=[str(tmp_path)],
+        patterns=["{variable}_{source}_{experiment}.nc"],
         read_from_file=[
-            ["experiment", "frequency"],
-            ["variable", "date_start", "date_end"],
+            ["variable", "source"],
+            ["variable"],
         ],
-        cvs={"variable": {"sftlf": None, "tas": "t2m"}},
+        homogenous_info={"domain": "global", "frequency": "fx"},
     )
-    assert len(df) == 10
-    t2m = df.variable.apply(lambda v: "t2m" in v)
-    assert (df[t2m]["date_end"] == pd.Timestamp("2002-12-31")).all()
-    assert (df[~t2m].variable.apply(len) == 0).all()
+    assert len(df) == 4
+    assert df.iloc[0].variable == ("abc", "ghi")
 
 
 @pytest.mark.requires_netcdf


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

This is a pattern used for MRCC monthly files. The file name contains a variable name, but the file itself contains more than that. Thus, "variable" appears in the pattern and is parsed, but to have all variables, we read them from file with this argument : `read_from_file=[['variable', ...], ['variable']]`. 

Since Pandas 3, a new StringDType exists, for the result of the first filenames parsing has a `variable` column of this dtype. And when setting an element to a tuple, it fails. Earlier, it was an Object dtype, so there were no issue. 

The fix simply changes the dtype of the column on the fly when this situation happens.

### Does this PR introduce a breaking change?
No.


### Other information:
