### PR TITLE
Drop nans before interpolating WL period

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Bug fixes
 * When creating cartopy CRS objects from CF attributes, xscen will default to a spherical earth of radius 6370997 m. This fixes issues raised by the update of PROJ 9.8 (:pull:`701`).
 * Fix a bug stemming from a change in Pandas 3 in ``parse_directory`` when ``read_from_file`` tries to overwrite a column previously parsed as strings. (:pull:`703`).
 * Fix bug in ``xs.spatial_mean`` where the function would fail if the dataset had a `crs` coords instead of `rotated_pole`. (:pull:`716`, :issue:`718`).
+* Fix bug in ``xs.get_period_from_warming_level`` when requesting ``window > 50``. (:pull:`722`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -895,8 +895,8 @@ def get_period_from_warming_level(  # noqa: C901
 
         if window % 2 != 0:  # odd window
             rolling_diff = rolling_diff.shift(time=1)
-        # ensure series is monotonic -- keep only first year above point
-        rolling_diff = rolling_diff.cumulative("time").max()
+        # ensure series is monotonic -- keep only first year above point, drop any nans
+        rolling_diff = rolling_diff.cumulative("time").max().dropna('time')
         # create interpolator
         interp = interp1d(
             rolling_diff,

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -896,7 +896,7 @@ def get_period_from_warming_level(  # noqa: C901
         if window % 2 != 0:  # odd window
             rolling_diff = rolling_diff.shift(time=1)
         # ensure series is monotonic -- keep only first year above point, drop any nans
-        rolling_diff = rolling_diff.cumulative("time").max().dropna('time')
+        rolling_diff = rolling_diff.cumulative("time").max().dropna("time")
         # create interpolator
         interp = interp1d(
             rolling_diff,


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
It seems that `get_period_from_warming_level` can't handle timeseries with nans at the beginning,  scipy's interpolator returns the first value when it is nan.

This fixes the issue by dropping any nans in the timeseries, letting the interpolator work only on "known" data points.

I think we didn't see the issue before because it would only happen when the beginning of a tas timeseries is missing, which only happens when a window larger than 50 is requested (as we always have 1850-1900 for all simulations).

Another way to do this would be `bfill('time')` as NaNs can only be present at the beginning of the series. Both approach seem equivalent.

### Illustration of issue
```python3
xs.get_period_from_warming_level("CMIP6_NorESM2-MM_ssp126_r1i1p1f1", 0.69, window=55)
# ['1823', '1877']
```

```python3
ds = xr.open_dataset('/home/pbourg/Projets/xscen/src/xscen/data/IPCC_annual_global_tas.nc')

t = ds.tas.where((ds.experiment == 'ssp126') & (ds.source == 'NorESM2-MM'), drop=True).squeeze('simulation')
r = t.sel(time=slice('1850', '1900')).mean('time')

rd = (t - r).rolling(time=55, center=True, min_periods=55).mean().shift(time=1).cumulative('time').max()
```
Where "rd" is the rolling diff, the yearly max of warming level reached by the model. For NorESM2-MM, we only have data for 1850-1900 and then for 1950 and after. With a window of 55, the first chunk is dropped, so the "rd" is nan from 1850 to 
1977.

Then, we we get to the interpolator, nan are not managed and the first y (1850) is returned.