### PR TITLE
Add Ouranos logo to README and docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Internal changes
     * `Makefile` now handles some dependency installation logic.
     * `tox.toml` has been adjusted to use Makefile commands.
     * `tox.toml` no longer reinstalls `h5py` explicitly.
+* Added acknowledgement of funding support and Ouranos logo to documentation landing page and ``README.rst``. (:pull:`724`).
 
 .. _changes_0.14.0:
 

--- a/README.rst
+++ b/README.rst
@@ -38,14 +38,14 @@ Acknowledgments
 `xscen` development is funded through Ouranos_, a not-for-profit collaborative innovation organization fostering resilient adaptation to climate change, based in Québec, Canada.
 
 .. image:: https://raw.githubusercontent.com/Ouranosinc/.github/refs/heads/main/images/logo-ouranos-horizontal-couleur.svg
-        :target: https://www.ouranos.ca/
+        :target: https://www.ouranos.ca/en
         :align: center
 
 This package was created with Cookiecutter_ and the `Ouranosinc/cookiecutter-pypackage`_ project template.
 
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 .. _DerivedVariableRegistry: https://intake-esm.readthedocs.io/en/latest/how-to/define-and-use-derived-variable-registry.html
-.. _Ouranos: https://www.ouranos.ca/
+.. _Ouranos: https://www.ouranos.ca/en
 .. _Ouranosinc/cookiecutter-pypackage: https://github.com/Ouranosinc/cookiecutter-pypackage
 .. _installation docs: https://xscen.readthedocs.io/en/latest/installation.html
 .. _intake-esm: https://intake-esm.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -34,10 +34,18 @@ Please refer to the `installation docs`_.
 
 Acknowledgments
 ---------------
+
+`xscen` development is funded through Ouranos_, a not-for-profit collaborative innovation organization fostering resilient adaptation to climate change, based in Québec, Canada.
+
+.. image:: https://raw.githubusercontent.com/Ouranosinc/.github/refs/heads/main/images/logo-ouranos-horizontal-couleur.svg
+        :target: https://www.ouranos.ca/
+        :align: center
+
 This package was created with Cookiecutter_ and the `Ouranosinc/cookiecutter-pypackage`_ project template.
 
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 .. _DerivedVariableRegistry: https://intake-esm.readthedocs.io/en/latest/how-to/define-and-use-derived-variable-registry.html
+.. _Ouranos: https://www.ouranos.ca/
 .. _Ouranosinc/cookiecutter-pypackage: https://github.com/Ouranosinc/cookiecutter-pypackage
 .. _installation docs: https://xscen.readthedocs.io/en/latest/installation.html
 .. _intake-esm: https://intake-esm.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,10 +22,10 @@ Features
 
 Acknowledgments
 ^^^^^^^^^^^^^^^
-`xscen` development is funded through `Ouranos <https://www.ouranos.ca/>`_, a not-for-profit collaborative innovation organization fostering resilient adaptation to climate change, based in Québec, Canada.
+`xscen` development is funded through `Ouranos <https://www.ouranos.ca/en>`_, a not-for-profit collaborative innovation organization fostering resilient adaptation to climate change, based in Québec, Canada.
 
 .. image:: https://raw.githubusercontent.com/Ouranosinc/.github/refs/heads/main/images/logo-ouranos-horizontal-couleur.svg
-    :target: https://www.ouranos.ca/
+    :target: https://www.ouranos.ca/en
     :align: center
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,23 +2,31 @@
 Welcome to xscen's documentation!
 =================================
 
-xscen: A climate change scenario-building analysis framework, built with Intake-esm catalogs and xarray-based packages such as xclim and xESMF.
+**xscen**: A climate change scenario-building analysis framework, built with Intake-esm catalogs and xarray-based packages such as xclim and xESMF.
 
 Need help?
-==========
-* Ouranos employees can ask questions on the Ouranos private StackOverflow where you can tag subjects and people. (https://stackoverflow.com/c/ouranos/questions ).
-* Potential bugs in xscen can be reported as an issue here: https://github.com/Ouranosinc/xscen/issues .
+^^^^^^^^^^
+* Ouranos employees can ask questions on the Ouranos private StackOverflow where you can tag subjects and people. (https://stackoverflow.com/c/ouranos/questions)
+* Potential bugs in xscen can be reported as an issue here: https://github.com/Ouranosinc/xscen/issues
 * Problems with data on Ouranos' servers can be reported as an issue here: https://github.com/Ouranosinc/miranda/issues
-* To be aware of changes in xscen, you can "watch" the github repo. You can customize the watch function to notify you of new releases. (https://github.com/Ouranosinc/xscen )
+* To be aware of changes in xscen, you can "watch" the GitHub repository. You can customize the watch function to notify you of new releases. (https://github.com/Ouranosinc/xscen)
 
 Features
-========
-* Supports workflows with YAML configuration files for better transparency, reproducibility, and long-term backups.
-* Intake_esm-based catalog to find and manage climate data.
-* Climate dataset extraction, subsetting, and temporal aggregation.
-* Calculate missing variables through Intake-esm's DerivedVariableRegistry.
-* Regridding with xESMF.
-* Bias adjustment with xsdba.
+^^^^^^^^
+* Supports workflows with YAML configuration files for better transparency, reproducibility, and long-term backups
+* Intake-esm-based catalog to find and manage climate data
+* Climate dataset extraction, subsetting, and temporal aggregation
+* Calculate missing variables through Intake-esm's DerivedVariableRegistry
+* Regridding with xESMF
+* Bias adjustment with xsdba
+
+Acknowledgments
+^^^^^^^^^^^^^^^
+`xscen` development is funded through `Ouranos <https://www.ouranos.ca/>`_, a not-for-profit collaborative innovation organization fostering resilient adaptation to climate change, based in Québec, Canada.
+
+.. image:: https://raw.githubusercontent.com/Ouranosinc/.github/refs/heads/main/images/logo-ouranos-horizontal-couleur.svg
+    :target: https://www.ouranos.ca/
+    :align: center
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Adds a logo and a small sentence about Ouranos to the README and to the documentation landing page
* Slight adjusts up the landing page content for consistency

### Does this PR introduce a breaking change?

Links to Ouranos now default to the English site page. La majorité des utilisateurs de GitHub qui pourraient être intéressés parlent anglais. Désolé.

### Other information:

No theming support, so the standard colour logo is being used. For users with CSS theme overrides (e.g. `Dark Reader`), this will mess up the logo (but that's beyond scope).