### PR TITLE
Avoid add_bounds on 2D coordinates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
 ------------------------------------------------------------
-Contributors: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Asli Bese (:user:`aslibese`).
+Contributors: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Asli Bese (:user:`aslibese`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,6 +25,7 @@ Bug fixes
 * Fix a bug stemming from a change in Pandas 3 in ``parse_directory`` when ``read_from_file`` tries to overwrite a column previously parsed as strings. (:pull:`703`).
 * Fix bug in ``xs.spatial_mean`` where the function would fail if the dataset had a `crs` coords instead of `rotated_pole`. (:pull:`716`, :issue:`718`).
 * Fix bug in ``xs.get_period_from_warming_level`` when requesting ``window > 50``. (:pull:`722`).
+* Fix a bug in ``xs.aggregate.spatial_mean`` with the `cos-lat` method where the function would give incorrect results if the dataset had irregular grid cells. (:issue:`726`, :pull:`727`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/aggregate.py
+++ b/src/xscen/aggregate.py
@@ -19,6 +19,8 @@ import xarray as xr
 import xclim as xc
 import xclim.core.calendar
 
+from .regrid import create_bounds_gridmapping
+
 
 try:
     import xesmf as xe
@@ -575,7 +577,7 @@ def spatial_mean(  # noqa: C901
             dims = ds.cf["longitude"].dims + ds.cf["latitude"].dims
         else:
             if "longitude" not in ds.cf.bounds:
-                ds = ds.cf.add_bounds(["longitude", "latitude"])
+                ds = ds.assign_coords(**create_bounds_gridmapping(ds))
             # Weights the weights by the cell area (in °²)
             weights = weights * xr.DataArray(
                 shapely.area(shapely.polygons(shapely.linearrings(ds.lon_bounds, ds.lat_bounds))),
@@ -646,8 +648,6 @@ def spatial_mean(  # noqa: C901
         geoms = shapely.segmentize(polygon.geometry, 1)
 
         if ds.cf["longitude"].ndim == 2 and "longitude" not in ds.cf.bounds:
-            from .regrid import create_bounds_gridmapping
-
             ds = ds.assign_coords(**create_bounds_gridmapping(ds))
 
         savg = xe.SpatialAverager(ds, geoms, **kwargs_copy)

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -424,7 +424,7 @@ class TestSpatialMean:
         out = xs.aggregate.spatial_mean(ds, method="cos-lat")
         assert "rotated_pole" not in out
         assert "grid_mapping" not in out.tas.attrs
-        np.testing.assert_allclose(out.tas, 1.623069, rtol=1e-6)
+        np.testing.assert_allclose(out.tas, 1.692961, rtol=1e-6)
         assert "weighted mean(dim=('rlat', 'rlon'))" in out.attrs["history"]
 
     def test_cos_lat_errors(self):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #726 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Replace `ds.cf.add_bounds(["longitude", "latitude"])` by our `create_bounds_gridmapping` for 2D grids is `cos-lat`.

### Does this PR introduce a breaking change?

- Results will change slightly, but were probably wrong before.

### Other information:
