### PR TITLE
Fix for change in parse 1.21

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Bug fixes
 * Fix bug in ``xs.spatial_mean`` where the function would fail if the dataset had a `crs` coords instead of `rotated_pole`. (:pull:`716`, :issue:`718`).
 * Fix bug in ``xs.get_period_from_warming_level`` when requesting ``window > 50``. (:pull:`722`).
 * Fix a bug in ``xs.aggregate.spatial_mean`` with the `cos-lat` method where the function would give incorrect results if the dataset had irregular grid cells. (:issue:`726`, :pull:`727`).
+* Fix a bug ``xs.parse_directory`` when the `{...:_}` pattern is used and the `parse` module is newer than 1.20.2. (:pull:`729`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Bug fixes
 * Fix bug in ``xs.spatial_mean`` where the function would fail if the dataset had a `crs` coords instead of `rotated_pole`. (:pull:`716`, :issue:`718`).
 * Fix bug in ``xs.get_period_from_warming_level`` when requesting ``window > 50``. (:pull:`722`).
 * Fix a bug in ``xs.aggregate.spatial_mean`` with the `cos-lat` method where the function would give incorrect results if the dataset had irregular grid cells. (:issue:`726`, :pull:`727`).
-* Fix a bug ``xs.parse_directory`` when the `{...:_}` pattern is used and the `parse` module is newer than 1.20.2. (:pull:`729`).
+* Fix a bug in ``xs.parse_directory`` when the ``{...:_}`` pattern is used and the `parse` module is newer than 1.20.2. (:pull:`729`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/catutils.py
+++ b/src/xscen/catutils.py
@@ -84,6 +84,10 @@ def register_parse_type(name: str, regex: str = r"([^\_\/\\]*)", group_count: in
     group_count: int
         The number of regex groups in the previous regex string.
     """
+    if not name[0].isalpha():
+        raise ValueError("A pattern name should begin with a letter to avoid confusion with format modifiers.")
+    if name in parse.ALLOWED_TYPES:
+        raise ValueError("This name is already used for a base type in parse.")
 
     def _register_parse_type(func):
         EXTRA_PARSE_TYPES[name] = parse.with_pattern(regex, regex_group_count=group_count)(func)
@@ -98,7 +102,7 @@ def _parse_word(text: str) -> str:
     return text
 
 
-@register_parse_type("_", regex=r"([^\/\\]*)", group_count=1)
+@register_parse_type("yes_", regex=r"([^\/\\]*)", group_count=1)
 def _parse_level(text: str) -> str:
     r"""Parse helper to match strings with anything except / or \."""
     return text
@@ -175,6 +179,7 @@ def _compile_pattern(pattern: str) -> parse.Parser:
     Compile a parse pattern (if needed) for quicker evaluation.
 
     The `no_` default format spec is added where no format spec was given.
+    The `_` xscen format spec is translated to the extra parse format spec `yes_`.
     The field prefix "?" is converted to "_" so the field name is a valid python variable name.
     """
     if isinstance(pattern, parse.Parser):
@@ -184,6 +189,8 @@ def _compile_pattern(pattern: str) -> parse.Parser:
     for pre, field, fmt, _ in string.Formatter().parse(pattern):
         if not fmt:
             fmt = "no_"
+        elif fmt == "_":
+            fmt = "yes_"
         if field:
             if field.startswith("?"):
                 field = "_" + field[1:]

--- a/tests/test_catutils.py
+++ b/tests/test_catutils.py
@@ -28,10 +28,12 @@ def test_find_assets(exts, lens, dirglob, N):  # noqa: N803
 
 
 def test_name_parser():
+    # The first pattern shouldn't match because it's too short.
+    # Bug in xscen < 0.15 with parse >= 1.21
     d = cu._name_parser(
         "station-obs/GovCan/AHCCD/day/tasmin/tasmin_day_GovCan_AHCCD_1960-1999.nc",
         root="",
-        patterns=["{type}/{institution}/{source}/{frequency}/{variable}/{?var}_{?:_}_{DATES}.nc"],
+        patterns=["{source}/{type}/{institution}/{?:_}_{DATES}.nc", "{type}/{institution}/{source}/{frequency}/{variable}/{?var}_{?:_}_{DATES}.nc"],
     )
     assert d["type"] == "station-obs"
     assert d["date_start"] == "1960"


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
`parse` 1.21 has added support for the parsing of the grouping character of decimal numbers. For example `1_000_000` uses `_`. The decoding of this format spec modifier is done _before_ checking if the requested format is an "extra" (custom) type.  Thus, our custom `_` format was misinterpreted and our custom regex never applied.

Result : the `{?:_}` pattern matched _anything_. It is supposed to match everything except slashes `\ /`. This makes `parse_directory` fail to properly match file names. See the modified test for an example.


I also added a few checks on the (rarely used) decorator that registers these types.

### Does this PR introduce a breaking change?
No.


### Other information:
@aslibese FYI!  I suggest you make sure you have this fix or `parse < 1.21` (1.20.2 works fine) in the environment that builds the catalog!
