### PR TITLE
Actually vectorized subsetting on warming levels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
------------------------------------------------------------
+------------------------------------------------------------
 Contributors: Pascal Bourgault (:user:`aulemahal`).
 
 New features and enhancements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Contributors: Pascal Bourgault (:user:`aulemahal`).
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Performance enhancement of ``xs.subset_warminglevels`` when multiple realizations and/or multiple warming levels are requested. The change reduces the dask complexity of the function and adds support for subsetting timeseries with any frequencies. The function still can't do vectorized subsetting on sub-monthly timeseries with non-uniform calendars. (:pull:`736`).
+   + Also added a ``min_periods`` argument to allow subsetting periods shorter than the ``window``.
 
 .. _changes_0.15.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,18 +2,14 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
-    ------------------------------------------------------------
-    Contributors:
+`Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
+-----------------------------------------------------------
+Contributors: Pascal Bourgault (:user:`aulemahal`).
 
-    Changes
-    ^^^^^^^
-    * No change.
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Performance enhancement of ``xs.subset_warminglevels`` when multiple realizations and/or multiple warming levels are requested. The change reduces the dask complexity of the function and adds support for subsetting timeseries with any frequencies. The function still can't do vectorized subsetting on sub-monthly timeseries with non-uniform calendars.
 
-    Fixes
-    ^^^^^
-    * No change.
 
 .. _changes_0.15.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,7 @@ Contributors: Pascal Bourgault (:user:`aulemahal`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* Performance enhancement of ``xs.subset_warminglevels`` when multiple realizations and/or multiple warming levels are requested. The change reduces the dask complexity of the function and adds support for subsetting timeseries with any frequencies. The function still can't do vectorized subsetting on sub-monthly timeseries with non-uniform calendars.
-
+* Performance enhancement of ``xs.subset_warminglevels`` when multiple realizations and/or multiple warming levels are requested. The change reduces the dask complexity of the function and adds support for subsetting timeseries with any frequencies. The function still can't do vectorized subsetting on sub-monthly timeseries with non-uniform calendars. (:pull:`736`).
 
 .. _changes_0.15.0:
 

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1117,12 +1117,13 @@ def subset_warming_level(
     wl: float | Sequence[float],
     to_level: str = "warminglevel-{wl}vs{period0}-{period1}",
     wl_dim: str | bool = "+{wl}Cvs{period0}-{period1}",
+    min_periods: int | None = None,
     **kwargs,
 ) -> xr.Dataset | None:
     r"""
     Subsets the input dataset with only the window of time over which the requested level of global warming
     is first reached, using the IPCC Atlas method.
-    A warming level is considered reached only if the full `window` years are available in the dataset.
+    A warming level is considered reached only if at least `min_periods` years are available in the dataset.
 
     Parameters
     ----------
@@ -1148,6 +1149,11 @@ def subset_warming_level(
        `wl`, 'tas_baseline_period[0]' and 'tas_baseline_period[1]'.
        If None, no new dimensions will be added, invalid if `wl` is a sequence.
        If True, the dimension will include `wl` as numbers and units of "degC".
+    min_periods : int, optional
+       The minimum number of years from the warming level period available in the dataset to keep it.
+       If fewer years are available, `nan` is returned. This only concerns the subsetting, the full window
+       must still exist in the global mean temperature dataset for the given simulation.
+       Defaults to the same as `window`.
     \*\*kwargs :
         Instructions on how to search for warming levels, passed to :py:func:`get_period_from_warming_level`.
 
@@ -1158,11 +1164,12 @@ def subset_warming_level(
         If a single realization and warming level is requested and that warming level is never reached, None is returned.
         The dataset will have a new dimension `warminglevel` with `wl_dim` as coordinates.
         If `wl` was a list or if ds was multiple realizations (along a "realization" coord) the "time" axis
-        is a fake time starting in 1000-01-01 and with a length of `window` years.
+        is a fake time starting in 1000-01-01 and with a length of `window` years. Nans are appended when the subset is shorter than the window.
         Start and end of the subsets are added as bounds, in the new coordinate "warminglevel_bounds".
     """
     tas_baseline_period = standardize_periods(kwargs.get("tas_baseline_period", ["1850", "1900"]), multiple=False)
     window = kwargs.get("window", 20)
+    min_periods = min_periods or window
     if isinstance(wl, int | float):
         wl = [wl]
 
@@ -1214,7 +1221,7 @@ def subset_warming_level(
                 return True
             time = xr.DataArray(time, dims=("time",), coords={"time": time})
             sl = time.sel(time=slice(s, e)).time.dt.year.values
-            return len(sl) == 0 or (sl[-1] - sl[0] + 1) < window
+            return len(sl) == 0 or (sl[-1] - sl[0] + 1) < min_periods
 
         wl_not_reached = xr.apply_ufunc(
             _wl_not_reached,
@@ -1224,13 +1231,20 @@ def subset_warming_level(
             vectorize=True,
         )
 
+        date_cls = ds.indexes["time"][0].__class__
+        # sentinel value for NaT, having this value is highly improbable and it should always be smaller then the first time
+        # makes no sense to have data going before 1850 when working with warming levels
+        sentinel = date_cls(1849, 12, 31, 23, 59, 59)
         # Weird, but much easier to use xarray/pandas indexing for selecting years and much cleaner code using apply_ufunc
+
         def _bounds_to_sel(time, bnds, not_reached):
             time = xr.DataArray(time, dims=("time",), coords={"time": time})
             if not_reached:
                 sl = time.isel(time=slice(0, fake_time.size))
             else:
                 sl = time.sel(time=slice(*bnds))
+                if min_periods != window:
+                    sl = sl.pad(time=(0, fake_time.size - sl.time.size), constant_values=sentinel)
             return sl.values
 
         timesels = xr.apply_ufunc(
@@ -1243,12 +1257,10 @@ def subset_warming_level(
             output_core_dims=[["fake_time"]],
         ).assign_coords(fake_time=fake_time)
 
-        date_cls = ds.indexes["time"][0].__class__
-
         def _make_bounds(bnds, not_reached):
             # Need to return the proper dtype for apply_ufunc, this will be masked with wl_not_reached afterwards
             if not_reached:
-                return np.array([date_cls(1000, 1, 1), date_cls(1000, 1, 1)])
+                return np.array([sentinel, sentinel])
             s, e = bnds
             # xscen returns first and last year included in the period
             # cf conventions want the time point that finishes the periods
@@ -1258,11 +1270,14 @@ def subset_warming_level(
             _make_bounds, bounds, wl_not_reached, input_core_dims=[["wl_bounds"], []], vectorize=True, output_core_dims=[["wl_bounds"]]
         ).where(~wl_not_reached)
 
+        if min_periods != window:
+            sentinel_ds = xr.zeros_like(ds.isel(time=0)).assign_coords(time=[sentinel])
+            ds = xr.concat([sentinel_ds, ds], "time")
         ds_wl = (
             ds.sel(time=timesels)
             .drop_vars("time")
+            .where(~wl_not_reached & (timesels != sentinel))
             .rename(fake_time="time")
-            .where(~wl_not_reached)
             .assign_coords(warminglevel_bounds=bnds_crd)
             .drop_vars("wl_bounds")
         )
@@ -1271,7 +1286,7 @@ def subset_warming_level(
         start_yr, end_yr = get_period_from_warming_level(ds, wl=wl[0], return_central_year=False, **kwargs)
         # cut the window selected above and expand dims with wl_crd
         ds_wl = ds.sel(time=slice(start_yr, end_yr))
-        wl_not_reached = (start_yr is None) or (ds_wl.time.size == 0) or ((ds_wl.time.dt.year[-1] - ds_wl.time.dt.year[0] + 1) != window)
+        wl_not_reached = (start_yr is None) or (ds_wl.time.size == 0) or ((ds_wl.time.dt.year[-1] - ds_wl.time.dt.year[0] + 1) < min_periods)
         # WL not reached, not in ds, or not fully contained in ds.time
         if wl_not_reached:
             return None

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1233,7 +1233,6 @@ def subset_warming_level(
                 sl = time.sel(time=slice(*bnds))
             return sl.values
 
-        # from IPython import embed; embed()
         timesels = xr.apply_ufunc(
             _bounds_to_sel,
             ds.time,

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1154,136 +1154,137 @@ def subset_warming_level(
     Returns
     -------
     xr.Dataset or None
-        Warming level dataset, or None if `ds` can't be subsetted for the requested warming level.
+        Warming level dataset.
+        If a single realization and warming level is requested and that warming level is never reached, None is returned.
         The dataset will have a new dimension `warminglevel` with `wl_dim` as coordinates.
-        If `wl` was a list or if ds had a "realization" dim, the "time" axis is replaced
-        by a fake time starting in 1000-01-01 and with a length of `window` years.
-        Start and end years of the subsets are bound in the new coordinate "warminglevel_bounds".
+        If `wl` was a list or if ds was multiple realizations (along a "realization" coord) the "time" axis
+        is a fake time starting in 1000-01-01 and with a length of `window` years.
+        Start and end of the subsets are added as bounds, in the new coordinate "warminglevel_bounds".
     """
     tas_baseline_period = standardize_periods(kwargs.get("tas_baseline_period", ["1850", "1900"]), multiple=False)
     window = kwargs.get("window", 20)
-
-    # If wl was originally a list, this function is called a 2nd time with a generated fake_time
-    fake_time = kwargs.pop("_fake_time", None)
-    # Fake time generation is needed : real is a dim or multiple levels
-    if fake_time is None and not isinstance(wl, int | float) or "realization" in ds.coords:
-        freq = xr.infer_freq(ds.time)
-        # FIXME: This is because I couldn't think of an elegant way to generate a fake_time otherwise.
-        if not compare_offsets(freq, "==", "YS"):
-            raise NotImplementedError(
-                "Passing multiple warming levels or vectorizing subsetting along the 'realization' dim is currently not supported for non-annual data"
-            )
-        fake_time = xr.date_range("1000-01-01", periods=window, freq=freq, calendar=ds.time.dt.calendar)
-
-    # If we got a wl sequence, call ourself multiple times and concatenate
-    if not isinstance(wl, int | float):
-        if not wl_dim or (isinstance(wl_dim, str) and "{wl}" not in wl_dim):
-            raise ValueError("`wl_dim` must be True or a template string including '{wl}' if multiple levels are passed.")
-        ds_wl = xr.concat(
-            [
-                subset_warming_level(
-                    ds,
-                    wli,
-                    to_level=to_level,
-                    wl_dim=wl_dim,
-                    _fake_time=fake_time,
-                    **kwargs,
-                )
-                for wli in wl
-            ],
-            "warminglevel",
-        )
-        return ds_wl
+    if isinstance(wl, int | float):
+        wl = [wl]
 
     # Creating the warminglevel coordinate
     if isinstance(wl_dim, str):  # a non-empty string
         wl_crd = xr.DataArray(
             [
                 wl_dim.format(
-                    wl=wl,
+                    wl=w,
                     period0=tas_baseline_period[0],
                     period1=tas_baseline_period[1],
                 )
+                for w in wl
             ],
             dims=("warminglevel",),
             name="warminglevel",
         )
     else:
-        wl_crd = xr.DataArray([wl], dims=("warminglevel",), name="warminglevel", attrs={"units": "degC"})
+        wl_crd = xr.DataArray(wl, dims=("warminglevel",), name="warminglevel", attrs={"units": "degC"})
 
-    # For generating the bounds coord
-    date_cls = xc.core.calendar.datetime_classes[ds.time.dt.calendar]
-    if "realization" in ds.coords:
-        # Vectorized subset
-        realdim = ds.realization.dims[0]
-        bounds = get_period_from_warming_level(ds.realization, wl, return_central_year=False, **kwargs)
-        reals = []
-        for real in bounds[realdim].values:
-            start, end = bounds.sel({realdim: real}).values
-            start = None if pd.isna(start) else start
-            end = None if pd.isna(end) else end
-            data = ds.sel({realdim: [real], "time": slice(start, end)})
-            wl_not_reached = (start is None) or (data.time.size == 0) or ((data.time.dt.year[-1] - data.time.dt.year[0] + 1) != window)
-            if not wl_not_reached:
-                bnds_crd = [
-                    date_cls(int(start), 1, 1),
-                    date_cls(int(end) + 1, 1, 1) - datetime.timedelta(seconds=1),
-                ]
-            else:
-                # In the case of not reaching the WL, data might be too short
-                # We create it again with the proper length
-                data = ds.sel({realdim: [real]}).isel(time=slice(0, fake_time.size)) * np.nan
-                bnds_crd = [np.nan, np.nan]
-            reals.append(
-                data.expand_dims(warminglevel=wl_crd).assign_coords(
-                    time=fake_time[: data.time.size],
-                    warminglevel_bounds=(
-                        (realdim, "warminglevel", "wl_bounds"),
-                        [[bnds_crd]],
-                    ),
-                )
+    if "realization" in ds.coords or len(wl) > 1:
+        # Vectorized subset (multiple sims, multiple wls or both)
+
+        # Fake time generation is needed
+        freq = xr.infer_freq(ds.time)
+        if compare_offsets(freq, "<", "MS") and ds.time.dt.calendar not in ["noleap", "all_leap", "360_day"]:
+            raise ValueError(
+                "Subsetting by warming levels with multiple realizations and/or multiple warming levels is not implemented "
+                f"for frequencies finer than monthly and non-uniform calendars. Got freq={freq} and calendar={ds.time.dt.calendar}"
             )
-        ds_wl = xr.concat(reals, realdim)
+        fake_time = xr.date_range("1000-01-01", f"{1000 + window - 1}-12-31", freq=freq, calendar=ds.time.dt.calendar)
+
+        if "realization" in ds.coords:
+            bounds = get_period_from_warming_level(ds.realization, wl, return_central_year=False, **kwargs)
+            if len(wl) == 1:
+                bounds = bounds.expand_dims(warminglevel=wl_crd)
+            else:
+                bounds = bounds.rename(wl="warminglevel").assign_coords(warminglevel=wl_crd)
+        else:
+            bounds = xr.DataArray(
+                get_period_from_warming_level(ds, wl, return_central_year=False, **kwargs),
+                dims=("warminglevel", "wl_bounds"),
+                coords={"warminglevel": wl_crd, "wl_bounds": [0, 1]},
+            )
+
+        # Weird, but much easier to use xarray/pandas indexing for selecting years and much cleaner code using apply_ufunc
+        def _bounds_to_sel(time, bnds):
+            s, e = bnds
+            time = xr.DataArray(time, dims=("time",), coords={"time": time})
+            if not isinstance(s, str) and np.isnan(s):
+                sl = time.isel(time=slice(0, fake_time.size))
+            else:
+                sl = time.sel(time=slice(s, e))
+            if sl.time.size != fake_time.size:
+                sl = time.isel(time=slice(0, fake_time.size))
+            return sl.values
+
+        # from IPython import embed; embed()
+        timesels = xr.apply_ufunc(
+            _bounds_to_sel,
+            ds.time,
+            bounds,
+            input_core_dims=[["time"], ["wl_bounds"]],
+            vectorize=True,
+            output_core_dims=[["fake_time"]],
+        ).assign_coords(fake_time=fake_time)
+
+        def _wl_not_reached(time, bnds):
+            s, e = bnds
+            if not isinstance(s, str) and np.isnan(s):
+                return True
+            time = xr.DataArray(time, dims=("time",), coords={"time": time})
+            sl = time.sel(time=slice(s, e)).time.dt.year.values
+            return len(sl) == 0 or (sl[-1] - sl[0] + 1) < window
+
+        wl_not_reached = xr.apply_ufunc(
+            _wl_not_reached,
+            ds.time,
+            bounds,
+            input_core_dims=[["time"], ["wl_bounds"]],
+            vectorize=True,
+        )
+
+        date_cls = ds.indexes["time"][0].__class__
+
+        def _make_bounds(bnds):
+            s, e = bnds
+            if not isinstance(s, str) and np.isnan(s):
+                return np.array([np.nan, np.nan])
+            # xscen returns first and last year included in the period
+            # cf conventions want the time point that finishes the periods
+            return np.array([date_cls(int(s), 1, 1), date_cls(int(e) + 1, 1, 1)])
+
+        bnds_crd = xr.apply_ufunc(_make_bounds, bounds, input_core_dims=[["wl_bounds"]], vectorize=True, output_core_dims=[["wl_bounds"]])
+
+        ds_wl = (
+            ds.sel(time=timesels)
+            .drop_vars("time")
+            .rename(fake_time="time")
+            .where(~wl_not_reached)
+            .assign_coords(warminglevel_bounds=bnds_crd)
+            .drop_vars("wl_bounds")
+        )
     else:
-        # Scalar subset, single level
-        start_yr, end_yr = get_period_from_warming_level(ds, wl=wl, return_central_year=False, **kwargs)
+        # Single sim, single wl
+        start_yr, end_yr = get_period_from_warming_level(ds, wl=wl[0], return_central_year=False, **kwargs)
         # cut the window selected above and expand dims with wl_crd
         ds_wl = ds.sel(time=slice(start_yr, end_yr))
         wl_not_reached = (start_yr is None) or (ds_wl.time.size == 0) or ((ds_wl.time.dt.year[-1] - ds_wl.time.dt.year[0] + 1) != window)
-        if fake_time is None:
-            # WL not reached, not in ds, or not fully contained in ds.time
-            if wl_not_reached:
-                return None
-            ds_wl = ds_wl.expand_dims(warminglevel=wl_crd)
-        else:
-            # WL not reached, not in ds, or not fully contained in ds.time
-            if wl_not_reached:
-                ds_wl = ds.isel(time=slice(0, fake_time.size)) * np.nan
-                wlbnds = (("warminglevel", "wl_bounds"), [[np.nan, np.nan]])
-            else:
-                wlbnds = (
-                    ("warminglevel", "wl_bounds"),
-                    [
-                        [
-                            date_cls(int(start_yr), 1, 1),
-                            date_cls(int(end_yr) + 1, 1, 1) - datetime.timedelta(seconds=1),
-                        ]
-                    ],
-                )
-            # We are in an iteration over multiple levels, put the fake time axis, but remember bounds
-            ds_wl = ds_wl.expand_dims(warminglevel=wl_crd).assign_coords(
-                time=fake_time[: ds_wl.time.size],
-                warminglevel_bounds=wlbnds,
-            )
+        # WL not reached, not in ds, or not fully contained in ds.time
+        if wl_not_reached:
+            return None
+        ds_wl = ds_wl.expand_dims(warminglevel=wl_crd)
 
     if to_level is not None:
         ds_wl.attrs["cat:processing_level"] = to_level.format(
-            wl=wl,
+            wl=wl[0] if len(wl) == 1 else wl,
             period0=tas_baseline_period[0],
             period1=tas_baseline_period[1],
         )
 
-    if not wl_dim:
+    if not wl_dim and len(wl) == 1:
         ds_wl = ds_wl.squeeze("warminglevel", drop=True)
     else:
         ds_wl.warminglevel.attrs.update(

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1270,7 +1270,7 @@ def subset_warming_level(
             _make_bounds, bounds, wl_not_reached, input_core_dims=[["wl_bounds"], []], vectorize=True, output_core_dims=[["wl_bounds"]]
         ).where(~wl_not_reached)
 
-        if min_periods != window:
+        if min_periods != window and (timesels == sentinel).any():
             sentinel_ds = xr.zeros_like(ds.isel(time=0)).assign_coords(time=[sentinel])
             ds = xr.concat([sentinel_ds, ds], "time")
         ds_wl = (

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1251,12 +1251,15 @@ def subset_warming_level(
         def _make_bounds(bnds):
             s, e = bnds
             if not isinstance(s, str) and np.isnan(s):
-                return np.array([np.nan, np.nan])
+                # Need to return the proper dtype, this will be masked with wl_not_reached
+                return np.array([date_cls(1000, 1, 1), date_cls(1000, 1, 1)])
             # xscen returns first and last year included in the period
             # cf conventions want the time point that finishes the periods
             return np.array([date_cls(int(s), 1, 1), date_cls(int(e) + 1, 1, 1)])
 
-        bnds_crd = xr.apply_ufunc(_make_bounds, bounds, input_core_dims=[["wl_bounds"]], vectorize=True, output_core_dims=[["wl_bounds"]])
+        bnds_crd = xr.apply_ufunc(_make_bounds, bounds, input_core_dims=[["wl_bounds"]], vectorize=True, output_core_dims=[["wl_bounds"]]).where(
+            ~wl_not_reached
+        )
 
         ds_wl = (
             ds.sel(time=timesels)

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1210,7 +1210,7 @@ def subset_warming_level(
 
         def _wl_not_reached(time, bnds):
             s, e = bnds
-            if not isinstance(s, str) and np.isnan(s):
+            if not isinstance(s, str) or not isinstance(e, str):
                 return True
             time = xr.DataArray(time, dims=("time",), coords={"time": time})
             sl = time.sel(time=slice(s, e)).time.dt.year.values

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -1208,28 +1208,6 @@ def subset_warming_level(
                 coords={"warminglevel": wl_crd, "wl_bounds": [0, 1]},
             )
 
-        # Weird, but much easier to use xarray/pandas indexing for selecting years and much cleaner code using apply_ufunc
-        def _bounds_to_sel(time, bnds):
-            s, e = bnds
-            time = xr.DataArray(time, dims=("time",), coords={"time": time})
-            if not isinstance(s, str) and np.isnan(s):
-                sl = time.isel(time=slice(0, fake_time.size))
-            else:
-                sl = time.sel(time=slice(s, e))
-            if sl.time.size != fake_time.size:
-                sl = time.isel(time=slice(0, fake_time.size))
-            return sl.values
-
-        # from IPython import embed; embed()
-        timesels = xr.apply_ufunc(
-            _bounds_to_sel,
-            ds.time,
-            bounds,
-            input_core_dims=[["time"], ["wl_bounds"]],
-            vectorize=True,
-            output_core_dims=[["fake_time"]],
-        ).assign_coords(fake_time=fake_time)
-
         def _wl_not_reached(time, bnds):
             s, e = bnds
             if not isinstance(s, str) and np.isnan(s):
@@ -1246,20 +1224,40 @@ def subset_warming_level(
             vectorize=True,
         )
 
+        # Weird, but much easier to use xarray/pandas indexing for selecting years and much cleaner code using apply_ufunc
+        def _bounds_to_sel(time, bnds, not_reached):
+            time = xr.DataArray(time, dims=("time",), coords={"time": time})
+            if not_reached:
+                sl = time.isel(time=slice(0, fake_time.size))
+            else:
+                sl = time.sel(time=slice(*bnds))
+            return sl.values
+
+        # from IPython import embed; embed()
+        timesels = xr.apply_ufunc(
+            _bounds_to_sel,
+            ds.time,
+            bounds,
+            wl_not_reached,
+            input_core_dims=[["time"], ["wl_bounds"], []],
+            vectorize=True,
+            output_core_dims=[["fake_time"]],
+        ).assign_coords(fake_time=fake_time)
+
         date_cls = ds.indexes["time"][0].__class__
 
-        def _make_bounds(bnds):
-            s, e = bnds
-            if not isinstance(s, str) and np.isnan(s):
-                # Need to return the proper dtype, this will be masked with wl_not_reached
+        def _make_bounds(bnds, not_reached):
+            # Need to return the proper dtype for apply_ufunc, this will be masked with wl_not_reached afterwards
+            if not_reached:
                 return np.array([date_cls(1000, 1, 1), date_cls(1000, 1, 1)])
+            s, e = bnds
             # xscen returns first and last year included in the period
             # cf conventions want the time point that finishes the periods
             return np.array([date_cls(int(s), 1, 1), date_cls(int(e) + 1, 1, 1)])
 
-        bnds_crd = xr.apply_ufunc(_make_bounds, bounds, input_core_dims=[["wl_bounds"]], vectorize=True, output_core_dims=[["wl_bounds"]]).where(
-            ~wl_not_reached
-        )
+        bnds_crd = xr.apply_ufunc(
+            _make_bounds, bounds, wl_not_reached, input_core_dims=[["wl_bounds"], []], vectorize=True, output_core_dims=[["wl_bounds"]]
+        ).where(~wl_not_reached)
 
         ds_wl = (
             ds.sel(time=timesels)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -604,6 +604,24 @@ class TestSubsetWarmingLevel:
         ds_sub = xs.subset_warming_level(ds, wl=[1.5, 2, 20])
         assert ds_sub.time.size == 20 * 365
 
+    @pytest.mark.parametrize("calendar", ["noleap", "standard"])
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_minperiods(self, calendar, use_dask):
+        ds = self.ds
+        if use_dask:
+            ds = ds.chunk()
+        if calendar != "standard":
+            ds = ds.convert_calendar(calendar)
+
+        # Multi reals
+        ds_multi = ds.expand_dims(realization=["CMIP6_CanESM5_ssp126_r1i1p1f1", "CMIP6_CanESM5_ssp245_r1i1p1f1"])
+        ds_sub = xs.subset_warming_level(ds_multi, wl=1, window=30, min_periods=10)
+        np.testing.assert_array_equal(ds_sub.tas.isnull().sum("time").values, [[16], [16]])
+
+        # Single real
+        ds_sub = xs.subset_warming_level(ds, wl=1, window=30, min_periods=10)
+        assert ds_sub.time.size == 14
+
 
 class TestResample:
     @pytest.mark.parametrize(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -543,6 +543,7 @@ class TestSubsetWarmingLevel:
                     ],
                 )
             )
+            dim = "real"
         else:
             ds = self.ds.expand_dims(
                 realization=[
@@ -551,14 +552,17 @@ class TestSubsetWarmingLevel:
                     "fake_faux_falsch_falso",
                 ]
             )
+            dim = "realization"
         ds_sub = xs.subset_warming_level(
             ds,
             wl=1.5,
             to_level="tests",
         )
         np.testing.assert_array_equal(ds_sub.time.dt.year, np.arange(1000, 1020))
-        np.testing.assert_array_equal(ds_sub.warminglevel_bounds[:2].dt.year, [[[2004, 2023]], [[2004, 2023]]])
-        assert ds_sub.warminglevel_bounds[2].isnull().all()
+        np.testing.assert_array_equal(
+            ds_sub.warminglevel_bounds.isel(**{dim: [0, 1]}).transpose(dim, "warminglevel", "wl_bounds").dt.year, [[[2004, 2024]], [[2004, 2024]]]
+        )
+        assert ds_sub.warminglevel_bounds.isel(**{dim: 2}).isnull().all()
 
     def test_multilevels(self):
         ds_sub = xs.subset_warming_level(
@@ -571,6 +575,34 @@ class TestSubsetWarmingLevel:
             ["+1Cvs1850-1900", "+2Cvs1850-1900", "+3Cvs1850-1900", "+20Cvs1850-1900"],
         )
         np.testing.assert_array_equal(ds_sub.tas.isnull().sum("time"), [20, 0, 20, 20])
+
+    def test_subyearly(self):
+        ds = timeseries(
+            np.arange(365 * 50),
+            variable="tas",
+            start="2000-01-01",
+            freq="D",
+            calendar="standard",
+            as_dataset=True,
+        ).assign_attrs(
+            {
+                "cat:mip_era": "CMIP6",
+                "cat:source": "CanESM5",
+                "cat:experiment": "ssp585",
+                "cat:member": "r1i1p1f1",
+            }
+        )
+        # single wl
+        ds_sub = xs.subset_warming_level(ds, wl=1.5)
+        assert ds_sub.time.equals(ds.sel(time=slice("2003", "2022")).time)
+
+        # multiple wl
+        with pytest.raises(ValueError, match="Subsetting by warming levels"):
+            ds_sub = xs.subset_warming_level(ds, wl=[1.5, 2, 20])
+
+        ds = ds.convert_calendar("noleap")
+        ds_sub = xs.subset_warming_level(ds, wl=[1.5, 2, 20])
+        assert ds_sub.time.size == 20 * 365
 
 
 class TestResample:


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
Rewrites `subset_warminglevel` to use a vectorized `sel` instead of re-building the output with `concats`. Then gain is a drastic decrease in dask complexity.  For a simple case where the input has 15 tasks, I went from 950 to 170. In general, I think the increase in dask tasks is x10 for simple inputs (not much done since opening), compared to x63 before.

This was achieved by building an array to pass to `da.sel(time=...)` instead of doing this part by part. Involves a few `apply_ufunc`, but I hope the code is still readable ?

Also, I added support for non-yearly frequencies here. It's no big deal for a scalar subset, but still requires an uniform time coordinate on the vectorized subset since we need to align all elements on the same "fake" time axis at the end.

Finally, I changed the definition of the `warminglevel_bounds` variable. In CF, common bounds are supposed to be identical for two non-overlapping but contiguous periods. This means that the right (end) bound should not be "1 second before the end", it should simply be the end, so midnight on January 1st of the year following the period. This change has been made in xclim for `time_bnds` a while ago, in both cases it was because of my faulty reading of the conventions.

### Does this PR introduce a breaking change?
Should not, except for `warminglevel_bounds`.


### Other information:
@SarahG-579462  Is this useful to you ?  Anyway, it will help PC's crunch a lot.
