### PR TITLE
Rewrite attrs coercition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,24 +2,12 @@
 Changelog
 =========
 
-..
-    `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
-    ------------------------------------------------------------
-    Contributors:
-
-    Changes
-    ^^^^^^^
-    * No change.
-
-    Fixes
-    ^^^^^
-    * No change.
 `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
 ------------------------------------------------------------
 Contributors: Pascal Bourgault (:user:`aulemahal`).
 
-Fixes
-^^^^^
+Bug fixes
+^^^^^^^^^
 * Rewrite the way attributes are coerced in ``save_to_zarr`` and ``save_to_netcdf`` to fix issues with numpy native dtypes. Sequences are always re-written as comma-separated lists (strings). (:pull:`743`).
 
 .. _changes_0.15.1:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Contributors: Pascal Bourgault (:user:`aulemahal`)
 
 Fixes
 ^^^^^
-* Rewrite the way attributes are coerced in ``save_to_zarr`` and ``save_to_netcdf`` to fix issues with numpy native dtypes. Sequences are always re-written as comma-separated lists (strings).
+* Rewrite the way attributes are coerced in ``save_to_zarr`` and ``save_to_netcdf`` to fix issues with numpy native dtypes. Sequences are always re-written as comma-separated lists (strings). (:pull:`743`).
 
 .. _changes_0.15.1:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Changelog
     ^^^^^
     * No change.
 
+`Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
+------------------------------------------------------------
+Contributors: Pascal Bourgault (:user:`aulemahal`)
+
+Fixes
+^^^^^
+* Rewrite the way attributes are coerced in ``save_to_zarr`` and ``save_to_netcdf`` to fix issues with numpy native dtypes. Sequences are always re-written as comma-separated lists (strings).
+
 .. _changes_0.15.1:
 
 `v0.15.1 <https://github.com/Ouranosinc/xscen/tree/0.15.1>`_ (2026-05-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,9 @@ Changelog
     Fixes
     ^^^^^
     * No change.
-
 `Unreleased <https://github.com/Ouranosinc/xscen>`_ (latest)
 ------------------------------------------------------------
-Contributors: Pascal Bourgault (:user:`aulemahal`)
+Contributors: Pascal Bourgault (:user:`aulemahal`).
 
 Fixes
 ^^^^^

--- a/src/xscen/io.py
+++ b/src/xscen/io.py
@@ -360,6 +360,8 @@ def save_to_netcdf(
     """
     Save a Dataset to NetCDF, rechunking or compressing if requested.
 
+    Attributes are coerced to built-in types before writing, sequences are written as comma-separated lists.
+
     Parameters
     ----------
     ds : xr.Dataset
@@ -449,6 +451,7 @@ def save_to_zarr(  # noqa: C901
     Save a Dataset to Zarr format, rechunking and compressing if requested.
 
     According to mode, removes variables that we don't want to re-compute in ds.
+    Attributes are coerced to built-in types before writing, sequences are written as comma-separated lists.
 
     Parameters
     ----------

--- a/src/xscen/io.py
+++ b/src/xscen/io.py
@@ -285,10 +285,15 @@ def clean_incomplete(
 def _coerce_attrs(attrs):
     """Ensure no funky objects in attrs."""
     for k in list(attrs.keys()):
-        if not (
-            isinstance(attrs[k], str | float | int | np.ndarray) or isinstance(attrs[k], tuple | list) and isinstance(attrs[k][0], str | float | int)
-        ):
+        # We defer to numpy's casting mechanism.
+        # If it's a type understood by numpy, all right. If not, cast as string
+        # If it's a sequence, write as comma separated list
+        val = np.atleast_1d(attrs[k])
+        if val.size == 1 and val.dtype == "O":
+            # single non-normal element
             attrs[k] = str(attrs[k])
+        elif val.size > 1:
+            attrs[k] = ", ".join(map(str, attrs[k]))
 
 
 def _np_bitround(array: xr.DataArray, keepbits: int):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -632,6 +632,37 @@ class TestSaveToZarr:
         assert (Path(tmpdir) / "test.zarr.zip").exists()
         assert not (Path(tmpdir) / "test1.zarr").exists()
 
+    def test_coerce_attrs(self, tmpdir):
+
+        class CustomObject:
+            pass
+
+        attrs = {"anNPint": np.int32(42), "adict": {"key": "value"}, "a_custom": CustomObject(), "amixedlist": [1, "2", np.uint16(3)]}
+        ds = xr.Dataset({"avar": 42}, attrs=attrs)
+        xs.save_to_zarr(ds, tmpdir / "test.zarr")
+
+        ds2 = xr.open_zarr(tmpdir / "test.zarr")
+        assert ds2.attrs["anNPint"] == 42
+        assert isinstance(ds2.attrs["adict"], str)
+        assert isinstance(ds2.attrs["a_custom"], str)
+        assert isinstance(ds2.attrs["amixedlist"], str)
+
+
+def test_coerce_attrs_netcdf(tmpdir):
+
+    class CustomObject:
+        pass
+
+    attrs = {"anNPint": np.int32(42), "adict": {"key": "value"}, "a_custom": CustomObject(), "amixedlist": [1, "2", np.uint16(3)]}
+    ds = xr.Dataset({"avar": 42}, attrs=attrs)
+    xs.save_to_netcdf(ds, tmpdir / "test.nc")
+
+    ds2 = xr.open_dataset(tmpdir / "test.nc")
+    assert ds2.attrs["anNPint"] == 42
+    assert isinstance(ds2.attrs["adict"], str)
+    assert isinstance(ds2.attrs["a_custom"], str)
+    assert isinstance(ds2.attrs["amixedlist"], str)
+
 
 @pytest.mark.parametrize("engine", ["netcdf", "zarr"])
 def test_savefuncs_normal(tmpdir, engine):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes Ouranosinc/data-requests#54
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
Rewrite of `_coerce_attrs`. I tried to be smart here and not have to list all the potential correct dtypes. Instead, I relied on numpy to "cast" the attribute into an array and used the resulting dtype. 

If "O" (object), then it's probably something funky, cast as string.
If not a scalar, format to a single string, comma-separated.

The last change was to fix a bug discovered while writing the test. At least h5py can't write attributes that are arrays of strings. I made the arbitrary decision not to try to support sequence attributes at all.

### Does this PR introduce a breaking change?
Sequence attributes are always formatted to a string.

Not sure how breaking this is.

### Other information:
