### PR TITLE
Use more memory when opening catalogs to support all cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Bug fixes
 ^^^^^^^^^
 * Rewrite the way attributes are coerced in ``save_to_zarr`` and ``save_to_netcdf`` to fix issues with numpy native dtypes. Sequences are always re-written as comma-separated lists (strings). (:pull:`743`).
 * ``xs.spatial.subset`` with ``method='gridpoint'`` now works with ``stack_drop_nans`` outputs. (:pull:`745`).
+* Turn off memory management when reading catalog's csv to support large catalogs with sparsely populated categorical columns. (:pull:`747`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/xscen/catalog.py
+++ b/src/xscen/catalog.py
@@ -130,6 +130,7 @@ csv_kwargs = {
         "variable": _parse_list_of_strings,
         "xrfreq": ensure_new_xrfreq,
     },
+    "low_memory": False,
 }
 """Kwargs to pass to `pd.read_csv` when opening an official Ouranos catalog."""
 


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
When reading a large CSV, pandas will default to parsing it in chunks and merge those later. However, when using categorical columns, the merge is not successful if the different chunks have different dtypes for the categories.

In our case, this can happen when a given column was empty for the whole chunk, yielding a value of "NaN" and this a "categorical" dtype of Float. Other chunks where this column has at least one value will use the categorical dtype of that value, most likely string.

It seems to be only happening in pandas 3, the catalog giving me this error was openable with pandas 2.2.3. I think this is specific to the "c" parser, which is the default.

I think we were simply lucky up to now in that our catalogs were small enough to use only one chunk, or that the first chunk never had completely empty columns. In my case, I stumbled upon this with the new "simulation" catalog on Narval when I added the MRCC5-CMIP6 data to it.

Solutions I thought of:
- Modify `ouracat.py` to "shuffle" the catalog so that the first chunk always has values in the categorical columns :  but I was like « ugh » and didn't to it
- Remove the use of categorical columns
- Switch to another parser. But "pyarrow" doesn't work because we are using "converters" which are unsupported. Another option would be "python", but it said to be slower.
- Turn off the chunking by putting `low_memory=False`.

I chose the last one over the second one ; speed over memory usage.

I haven't done any performance testing. But the catalog now opens.

I didn't add a test, because it would mean generating or uploading a large catalogs.

### Does this PR introduce a breaking change?


### Other information:
This will all be gone with the wind when we update to zarr 3 and the latest intake-esm. Because the latest intake-esm simply doesn't support categorical columns.