### PR TITLE
Zip delayed - delete unzipped by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Bug fixes
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``xs.spatial.get_crs`` now works with any DataArray. (:pull:`745`).
+* ``xs.io.save_to_zarr`` now supports writing to a zipped zarr when ``compute=False``. (:pull:`748`).
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* When passed a ``.zarr.zip`` path, ``xs.io.save_to_zarr`` will now delete the intermediate zarr folder by default if ``zip_zarrdir`` is not given. This can always be overridden by passing ``zip_kwargs={'delete': False}``. (:pull:`748`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xscen/io.py
+++ b/src/xscen/io.py
@@ -12,6 +12,7 @@ from inspect import signature
 from pathlib import Path
 from zipfile import ZipFile
 
+import dask
 import h5py
 import netCDF4
 import numpy as np
@@ -497,13 +498,15 @@ def save_to_zarr(  # noqa: C901
         then zipped to `filename`. For the initial zarr, if the zip_zarrdir ends in .zarr, it is used as is. If it
         does not end in .zarr, the name of `filename` is used inside this dir.
         If given, but `filename` does not end with .zip, this is ignored.
-        If not given and filename ends in zip, the initial zarr is saved directly to `filename` without .zip suffix, then zip to `filename`.
+        If not given and filename ends in zip, the initial zarr is saved directly to `filename` without .zip suffix,
+        then zip to `filename`, the first zarr is then deleted.
         It is possible to pass a path with environment variables like ${SLURM_TMPDIR} to ``zip_zarrdir``.
     zip_kwargs : dict, optional
         If given and `filename` ends in zip, the saved zarr directory is zipped using ``xs.io.zip_directory(**zip_kwargs)``.
         If `zipfile` arg is given, it is ignored. The `zipfile` is always set to `filename`.
         If given but `filename` does not end with .zip, this is ignored.
-        Tip: Pass `delete=True` here to erase the temporary zarr file.
+        If `filename` ends with .zip and `zip_zarrdir is not given, `zip_kwargs['delete']` defaults to True.
+        Otherwise, Pass `delete=True` here to erase the temporary zarr file.
 
     Returns
     -------
@@ -538,6 +541,7 @@ def save_to_zarr(  # noqa: C901
             # expand var allows to pass ${SLURM_TMPDIR} or similar
             path = Path(os.path.expandvars(zip_zarrdir)) / path.with_suffix("").name
         else:
+            zip_kwargs.setdefault("delete", True)
             path = Path(path.with_suffix(""))
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -635,8 +639,11 @@ def save_to_zarr(  # noqa: C901
             raise
 
     if Path(filename).suffix == ".zip":
-        zip_directory(path, **zip_kwargs)
-        z = None
+        if compute:
+            zip_directory(path, **zip_kwargs)
+            z = None
+        else:
+            z = then_zip(z, path, **zip_kwargs)
     return z
 
 
@@ -1113,6 +1120,26 @@ def unzip_directory(zipfile: str | os.PathLike, root: str | os.PathLike):
 
     with ZipFile(zipfile, "r") as zf:
         zf.extractall(root)
+
+
+@dask.delayed(name="zip")
+def then_zip(comp, root, zipfile=None, **zip_kwargs):  # noqa: F841
+    """
+    Zip a zarr directory after computation.
+
+    Parameters
+    ----------
+    comp : dask.Delayed
+        Dask object representing the lazy `to_zarr` call.
+    root : path
+        The directory with the content to archive, should be a .zarr directory.
+    zipfile : path
+        The zip file to create. If omitted, defaults to `root` with a .zip suffix.
+    **zip_kwargs : dict
+        Any other arguments to pass to :py:func:`zip_directory`.
+    """
+    # TODO: can we extract information from `comp` ?
+    zip_directory(root, zipfile or Path(root).with_suffix(".zarr.zip"), **zip_kwargs)
 
 
 # TODO: Implement as CF compression-by-gathering in cf-xarray instead

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import datetime
 from pathlib import Path
 
+import dask
 import numpy as np
 import pandas as pd
 import pytest
@@ -597,12 +598,12 @@ class TestSaveToZarr:
         xs.save_to_zarr(ds1, Path(tmpdir) / "test.zarr.zip")
 
         assert (Path(tmpdir) / "test.zarr.zip").exists()
-        assert (Path(tmpdir) / "test.zarr").exists()
+        assert not (Path(tmpdir) / "test.zarr").exists()
 
-        xs.save_to_zarr(ds1, Path(tmpdir) / "test2.zarr.zip", zip_kwargs={"delete": True})
+        xs.save_to_zarr(ds1, Path(tmpdir) / "test2.zarr.zip", zip_kwargs={"delete": False})
 
         assert (Path(tmpdir) / "test2.zarr.zip").exists()
-        assert not (Path(tmpdir) / "test2.zarr").exists()
+        assert (Path(tmpdir) / "test2.zarr").exists()
 
         xs.save_to_zarr(ds1, Path(tmpdir) / "test3.zarr", zip_kwargs={"zipfile": Path(tmpdir) / "test4.zarr.zip"})
 
@@ -618,6 +619,11 @@ class TestSaveToZarr:
 
         assert (Path(tmpdir) / Path(tmpdir) / "test6.zarr.zip").exists()
         assert (Path(tmpdir) / "test7.zarr").exists()
+
+        task = xs.save_to_zarr(ds1, Path(tmpdir) / "test8.zarr.zip", compute=False)
+        dask.compute(task)
+        assert (Path(tmpdir) / "test8.zarr.zip").exists()
+        assert not (Path(tmpdir) / "test8.zarr").exists()
 
     def test_zarr_zip_warn(self, tmpdir):
         ds1 = timeseries(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?
* Adds `then_zip` function to call on the delayed result of `xr.to_zarr(..., compute=False)`. The idea is to add the zipping task to the task tree.
* Add support for saving to zipped zarr in `xs.io.save_to_zarr` with `compute=False`.
* Changes the default behaviour : if a `.zarr.zip` path is passed to `save_to_zarr`, but no `zip_zarrdir` is given, then it is assumed that the intermediate .zarr folder is not wanted and `zip_kwargs['delete'] = True`.

### Does this PR introduce a breaking change?
The intermediate zarr folder is now deleted by default if it's path is not specified.


### Other information:
I needed this for SPS, but ported it here also.