### PR TITLE
Add possibility to "unstack" iterable columns in catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Contributors:  Juliette Lavoie (:user:`juliettelavoie`).
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add CanESM5-1 to IPCC_annual_global_tas.nc. (:pull:`761`).
+* Add ``DataCatalog.unstack`` and ``DataCatalog.stack`` to transform iterable columns into multiple entries (and the opposite). (:issue:`762`, :pull:`763`).
 
 .. _changes_0.15.2:
 

--- a/src/xscen/catalog.py
+++ b/src/xscen/catalog.py
@@ -621,6 +621,59 @@ class DataCatalog(intake_esm.esm_datastore):
         data = data.drop(columns=["new_path"])
         return self.__class__({"esmcat": self.esmcat.model_dump(), "df": data})
 
+    def unstack(self, col="variable"):
+        """
+        For catalogs where 'col' is an iterable, creates multiple entries for each of the iterable elements.
+
+        Useful for splitting variable columns before filtering. The resulting catalog might not work correctly
+        with dataset creation, in which case :py:meth:`stack` should be called first.
+
+        Parameters
+        ----------
+        col : str
+            Name of the column to "unstack". Raises an error is the column is not iterable.
+        """
+        if col not in self.esmcat.columns_with_iterables:
+            raise ValueError(f"Can't unstack catalog along column '{col}' because it is not an iterable.")
+
+        def _unstack(irow):
+            i, row = irow
+            for vv in row.variable:
+                r = deepcopy(row)
+                r["variable"] = vv
+                yield r.to_frame().T
+
+        new = pd.concat(itertools.chain.from_iterable(map(_unstack, self.df.iterrows()))).reset_index(drop=True)
+        self.esmcat._df = new
+
+    def stack(self, col="variable"):
+        """
+        Group together all entries where only column "col" is changing by making it a tuple.
+
+        This is meant to be called after :py:meth:`unstack` to go back to a standard catalog.
+
+        Parameters
+        ----------
+        col : str
+            Name of the column to "stack". Raises an error is the column is already iterable.
+        """
+        if col in self.esmcat.columns_with_iterables:
+            raise ValueError(f"Can't stack catalog on column '{col}' because it is already an iterable.")
+
+        def _stack(grp):
+            r = deepcopy(grp.iloc[0])
+            r["variable"] = tuple(grp.variable.values)
+            return r.to_frame().T
+
+        grp_cols = list(set(self.df.columns) - {col})
+        new = (
+            self.df.groupby(grp_cols, dropna=False)  # groupby by everything except col
+            .apply(_stack)  # create single entry df with tuple for col
+            .droplevel(-1)  # old index is now last level of multiindex, drop it
+            .reset_index()  # put back all index levels as columns
+        )
+        self.esmcat._df = new
+
 
 class ProjectCatalog(DataCatalog):
     r"""

--- a/src/xscen/catalog.py
+++ b/src/xscen/catalog.py
@@ -1,7 +1,6 @@
 """Catalog objects and related tools."""
 
 import ast
-import itertools
 import json
 import logging
 import os
@@ -10,6 +9,7 @@ import shutil as sh
 from collections.abc import Generator, Mapping, Sequence
 from copy import deepcopy
 from functools import reduce
+from itertools import chain, product
 from operator import or_
 from pathlib import Path
 from typing import Any
@@ -302,7 +302,7 @@ class DataCatalog(intake_esm.esm_datastore):
         DataCatalog
             Catalog corresponding to a set of unique values in the specified columns.
         """
-        for values in itertools.product(*self.unique(columns)):
+        for values in product(*self.unique(columns)):
             sim = self.search(**dict(zip(columns, values, strict=False)))
             if sim:  # So we never yield empty catalogs
                 yield values, sim
@@ -330,8 +330,22 @@ class DataCatalog(intake_esm.esm_datastore):
             cat = super().search(**columns)
         else:
             cat = self.__class__({"esmcat": self.esmcat.model_dump(), "df": self.esmcat._df})
+
         if periods is not False:
             cat.esmcat._df = subset_file_coverage(cat.esmcat._df, periods=periods, coverage=0, duplicates_ok=True)
+
+        variables = columns.get(self.esmcat.aggregation_control.variable_column_name)
+        if variables:
+            if isinstance(variables, str):
+                variables = [variables]
+            # TODO: Fix all this in intake-esm
+            # _requested_variables not created when the catalog has non-iterable variable col, but we still need it
+            # Here we generalize the behaviour so the 3 fields are _always_ created.
+            all_deps = [dv.query["variable"] for dv in cat.derivedcat.values()]
+            deps = set(chain.from_iterable(all_deps))
+            cat._dependent_variables = list(deps)
+            cat._requested_variables = list(set(variables) | deps)
+            cat._requested_variables_true = variables
         return cat
 
     def drop_duplicates(self, columns: list[str] | None = None):
@@ -643,7 +657,7 @@ class DataCatalog(intake_esm.esm_datastore):
                 r["variable"] = vv
                 yield r.to_frame().T
 
-        new = pd.concat(itertools.chain.from_iterable(map(_unstack, self.df.iterrows()))).reset_index(drop=True)
+        new = pd.concat(chain.from_iterable(map(_unstack, self.df.iterrows()))).reset_index(drop=True)
         self.esmcat._df = new
 
     def stack(self, col="variable"):
@@ -1024,13 +1038,13 @@ def concat_data_catalogs(*dcs) -> DataCatalog:
     dvr = intake_esm.DerivedVariableRegistry()
     dvr._registry.update(registry)
     newcat = DataCatalog({"esmcat": dcs[0].esmcat.model_dump(), "df": df}, registry=dvr)
-    newcat._requested_variables = requested_variables
+    newcat._requested_variables = list(set(requested_variables))
     if requested_variables_true:
-        newcat._requested_variables_true = requested_variables_true
+        newcat._requested_variables_true = list(set(requested_variables_true))
     if dependent_variables:
-        newcat._dependent_variables = dependent_variables
+        newcat._dependent_variables = list(set(dependent_variables))
     if requested_variable_freqs:
-        newcat._requested_variable_freqs = requested_variable_freqs
+        newcat._requested_variable_freqs = list(set(requested_variable_freqs))
     return newcat
 
 

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -697,19 +697,12 @@ def search_data_catalogs(  # noqa: C901
                                 )
                                 for i in {"member", "experiment", "id"}.intersection(varcat.df.columns):
                                     varcat.df.loc[:, i] = scat.df[i].iloc[0]
-
-                        # TODO: Temporary fix until this is changed in intake_esm
-                        varcat._requested_variables_true = [var_id]
-                        varcat._dependent_variables = list(set(varcat._requested_variables).difference(varcat._requested_variables_true))
                     else:
                         # TODO: Add support for DerivedVariables that themselves require DerivedVariables
                         # TODO: Add support for DerivedVariables that exist on different frequencies (e.g. 1hr 'pr' & 3hr 'tas')
                         varcat = scat.search(variable=var_id, require_all_on=["id", "xrfreq"])
                         msg = f"At var {var_id}, after search cat has {varcat.derivedcat.keys()}"
                         logger.debug(msg)
-                        # TODO: Temporary fix until this is changed in intake_esm
-                        varcat._requested_variables_true = [var_id]
-                        varcat._dependent_variables = list(set(varcat._requested_variables).difference(varcat._requested_variables_true))
 
                         # We want to match lines with the correct freq,
                         # IF allow_resampling is True and xrfreq translates to a timedelta,

--- a/src/xscen/extract.py
+++ b/src/xscen/extract.py
@@ -656,6 +656,11 @@ def search_data_catalogs(  # noqa: C901
     if len(catalog) > 0:
         for (sim_id,), scat in catalog.iter_unique("id"):
             # Find all the entries that match search parameters
+            was_stacked = False
+            if "variable" in scat.esmcat.columns_with_iterables:
+                scat.unstack("variable")
+                was_stacked = True
+
             varcats = []
             for var_id, xrfreqs in variables_and_freqs.items():
                 if isinstance(xrfreqs, str):
@@ -752,7 +757,10 @@ def search_data_catalogs(  # noqa: C901
                         break
                     if "timedelta" in varcat.df.columns:
                         varcat.df.drop(columns=["timedelta"], inplace=True)
+
                     varcat._requested_variable_freqs = [xrfreq]
+                    if was_stacked and "variable" not in varcat.esmcat.columns_with_iterables:
+                        varcat.stack("variable")
                     varcats.append(varcat)
 
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 import shutil
 from pathlib import Path
 
+import numpy as np
 import pytest
+import xarray as xr
 
 import xscen as xs
 from xscen.testing import datablock_3d as _datablock_3d
@@ -85,3 +87,31 @@ def datablock_3d():
     xscen.testing.datablock_3d : For create a generic timeseries objects.
     """
     return _datablock_3d
+
+
+@pytest.fixture(scope="session")
+def samplecat_multivar(request, tmp_path_factory):
+    """Generate two datasets with multiple variables and returns a catalog of them."""
+    ds = xr.merge(
+        (
+            _datablock_3d(np.random.rand(24, 5, 5), "tasmax", "rlon", 0, "rlat", 0, freq="MS", as_dataset=True),
+            _datablock_3d(np.random.rand(24, 5, 5), "tasmin", "rlon", 0, "rlat", 0, freq="MS", as_dataset=True),
+        ),
+        compat="no_conflicts",
+    )
+    tmp_path = tmp_path_factory.mktemp("KPOP_data")
+    ds.to_netcdf(tmp_path / "Huntrix_Rumi.nc")
+    ds.to_netcdf(tmp_path / "Saja-Boys_Jinu.nc")
+    df = xs.parse_directory(
+        directories=[tmp_path],
+        patterns=["{institution}_{source}.nc"],
+        homogenous_info={
+            "mip_era": "CMIPK",
+            "type": "simulation",
+            "processing_level": "rad",
+            "activity": "POP",
+            "experiment": "idol",
+        },
+        read_from_file=True,
+    )
+    return xs.DataCatalog({"esmcat": xs.catalog.esm_col_data, "df": df})

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -247,5 +247,8 @@ def test_stack_unstack(samplecat_multivar):
 
     xr.testing.assert_identical(ds1, ds2)
 
+    ds3 = cat.search(variable="tasmax").to_dataset(create_ensemble_on=["institution", "source"])
+    assert "tasmin" not in ds3.data_vars
+
     cat.stack()
     assert "variable" in cat.esmcat.columns_with_iterables

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -148,6 +148,29 @@ def test_search_period():
     assert scat.df.date_start.max() <= pd.Timestamp("2015-01-01 00:00:00")
 
 
+def test_search_variable():
+    # Test that _requested_variables and similar fields are set.
+    cat = catalog.DataCatalog(SAMPLES_DIR.parent / "pangeo-cmip6.json")
+    scat = cat.search(variable="tasmax")
+    assert scat._requested_variables == ["tasmax"]
+    assert scat._requested_variables_true == ["tasmax"]
+    assert scat._dependent_variables == []
+
+    scat = cat.search(variable=["tasmax", "tasmin"])
+    assert scat._requested_variables == ["tasmax", "tasmin"]
+    assert scat._requested_variables_true == ["tasmax", "tasmin"]
+    assert scat._dependent_variables == []
+
+    reg = xs.indicators.registry_from_module(
+        xs.indicators.load_xclim_module(notebooks.parent.parent / "src" / "xscen" / "xclim_modules" / "conversions")
+    )
+    cat = catalog.DataCatalog(SAMPLES_DIR.parent / "pangeo-cmip6.json", registry=reg)
+    scat = cat.search(variable="tas")
+    assert scat._requested_variables == ["tasmax", "tasmin", "tas"]
+    assert scat._requested_variables_true == ["tas"]
+    assert scat._dependent_variables == ["tasmax", "tasmin"]
+
+
 def test_search_nothing():
     cat = catalog.DataCatalog(SAMPLES_DIR.parent / "pangeo-cmip6.json")
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -234,3 +234,18 @@ def test_project_catalog_create_fails(tmpdir):
             f"{root}/test.json",
             create=True,
         )
+
+
+def test_stack_unstack(samplecat_multivar):
+    cat = samplecat_multivar
+    ds1 = cat.to_dataset(create_ensemble_on=["institution", "source"])
+    assert "variable" in cat.esmcat.columns_with_iterables
+
+    cat.unstack()
+    ds2 = cat.to_dataset(create_ensemble_on=["institution", "source"])
+    assert "variable" not in cat.esmcat.columns_with_iterables
+
+    xr.testing.assert_identical(ds1, ds2)
+
+    cat.stack()
+    assert "variable" in cat.esmcat.columns_with_iterables

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -266,6 +266,19 @@ class TestSearchDataCatalogs:
             "another_experiment",
         )
 
+    def test_coarse_multi_vs_fine_single(self, tmp_path):
+        catsrc = """variable,source,frequency,path,format,date_start,date_end,xrfreq,processing_level,type,experiment,domain,id
+"('mrros',)",SPS,1hr,/project/ctb-frigon/bourgapa/SPS-output/daf-snt1-NESTMB022/series/2015/mrros_daf-snt1-NESTMB022_2015_se.nc,nc,2015-01-01,2015-12-31 23:59:59,h,raw,simulation,daf-snt1-NESTMB022,,SPS_daf-snt1-NESTMB022
+"('mrros', 'mrros_max', 'mrros_min', 'mrros_nans', 'mrros_perc', 'mrros_std')",SPS,mon,/project/ctb-frigon/bourgapa/SPS-output/daf-snt1-NESTMB022/series/2015/mrros_daf-snt1-NESTMB022_2015_sm.nc,nc,2015-01-01,2015-12-31 23:59:59,MS,raw,simulation,daf-snt1-NESTMB022,,SPS_daf-snt1-NESTMB022
+"""  # ruff: ignore[line-too-long]
+        with (tmp_path / "catalog.csv").open("w") as f:
+            f.write(catsrc)
+        cat = xs.DataCatalog.from_df(tmp_path / "catalog.csv")
+
+        _, scat = xs.search_data_catalogs(cat, {"mrros": "MS"}, allow_resampling=True).popitem()
+
+        assert scat.df.iloc[0].xrfreq == "MS"
+
 
 class TestGetWarmingLevel:
     def test_list(self):


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #762 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] This PR does not seem to break the templates.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `DataCatalog.unstack(col)` will take the iterables in "col" and create one entry per element, copying all other fields over.
* `DataCatalog.stack(col)` does the opposite : for all groups where all columns except "col" are the same, merge entries by making "col" a tuple.
* `search_data_catalogs` now will `unstack` before filtering and `stack` (if needed) at the end. 

`search_data_catalogs` has one step where it keeps only the coarsest frequencies for each variable in the result. But by grouping on "variable" is doesn't see that "(XYZ,)" is similar to "(XYZ, ABC)". That was my bug in #762 .

In general, I think this can help for some filtering stuff. Once unstacked, the datasets seems to open correctly, even though the same paths are opened multiple times.  So, re-stacking is not required, one can keep the non-iterable variable column.

### Does this PR introduce a breaking change?
I don't think so, but the test suite might not cover all `search_data_catalogs` cases...


### Other information:
The way this is done might not be compatible with the newest intake esm... We'll see!

This also introduces a new sample catalog and dataset to use in the tests. We didn't have any multi-variable catalog.